### PR TITLE
Added drone_mode cog.

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -5,6 +5,7 @@ import respond
 import storage
 import emote
 import sys
+import drone_mode
 
 bot = discord.ext.commands.Bot('')
 
@@ -13,6 +14,7 @@ bot.add_cog(join.Join(bot))
 bot.add_cog(assign.Assign(bot))
 bot.add_cog(respond.Respond(bot))
 bot.add_cog(emote.Emote(bot))
+bot.add_cog(drone_mode.Drone_Mode(bot))
 # bot.add_cog(storage.Storage(bot))
 
 bot.run(sys.argv[1])

--- a/drone_mode.py
+++ b/drone_mode.py
@@ -1,0 +1,56 @@
+from discord.ext import commands
+from discord.utils import get
+import discord
+import messages
+from roles import HIVE_MXTRESS, DRONE_MODE
+import re
+
+def get_acceptable_messages(author):
+
+    user_id = get_user_id(author.display_name)
+
+    return [
+        user_id + ' :: Yes, Hive Mxtress.',
+        user_id + ' :: No, Hive Mxtress.',
+        user_id + ' :: Yes, Hive Mxtress',
+        user_id + ' :: No, Hive Mxtress'
+    ]
+
+def get_user_id(username):
+    return re.search(r"\d{4}", username).group()
+
+def has_role(member: discord.Member, role: str) -> bool:
+    return get(member.roles, name=role) is not None
+
+class Drone_Mode(commands.Cog):
+
+    def __init__(self,bot):
+        self.bot = bot
+
+    @commands.Cog.listener()
+    async def on_ready(self):
+        print("Drone mode cog online.")
+
+    @commands.Cog.listener()
+    async def on_message(self, message):
+        #If the message is written by a drone mode drone, and the message is NOT a valid message, delete it.
+        print(get_user_id(message.author.display_name))
+        if(has_role(message.author, DRONE_MODE)):
+            print("The drone mode drone has talked!")
+            if(message.content not in get_acceptable_messages(message.author)):
+                await message.delete()
+
+    @commands.command()
+    async def dronemode(self, context):
+        if(has_role(context.message.author, HIVE_MXTRESS)):
+            target_drone = context.message.mentions[0]
+            if has_role(target_drone, DRONE_MODE):
+                await context.send("Dronemode role toggled off for " + target_drone.display_name)
+                await target_drone.remove_roles(get(context.guild.roles, name=DRONE_MODE))
+            else:
+                await context.send("Dronemode role toggled on for " + target_drone.display_name)
+                await target_drone.add_roles(get(context.guild.roles, name=DRONE_MODE))
+        else:
+            await context.send("This command can only be used by the Hive Mxtress.")
+
+        

--- a/roles.py
+++ b/roles.py
@@ -10,4 +10,6 @@ HIVE_MXTRESS = 'Drone Hive Mxtress'
 GAGGED = '⬡-Gagged'
 ENFORCER = '⬡-Enforcer'
 
+DRONE_MODE = '⬡-DroneMode'
+
 MODERATION_ROLES = [ADMIN, MODERATION, HIVE_MXTRESS]


### PR DESCRIPTION
The new drone_mode cog toggles the "DroneMode" role on a specified user whenever the the "dronemode" command is envoked by the Hive Mxtress.

When a user with the DroneMode role sends a message, if their message does not match acceptable content ([ID] :: Yes, Hive Mxtress, [ID] : No, Hive Mxtress). It will be deleted.