### PR TITLE
Enforces ID for all drones on drone comms channel

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -6,6 +6,7 @@ import storage
 import emote
 import sys
 import drone_mode
+import drone_talk
 
 bot = discord.ext.commands.Bot('')
 
@@ -16,5 +17,6 @@ bot.add_cog(respond.Respond(bot))
 bot.add_cog(emote.Emote(bot))
 bot.add_cog(drone_mode.Drone_Mode(bot))
 bot.add_cog(storage.Storage(bot))
+bot.add_cog(drone_talk.Drone_Talk(bot))
 
 bot.run(sys.argv[1])

--- a/channels.py
+++ b/channels.py
@@ -14,6 +14,7 @@ LEWD_CREATIVE_LABOR_CHANNEL = 'lewd-creative-labor'
 
 #HexCorp-Drone-Hive
 ASSIGNMENT_CHANNEL = 'drone-hive-assignment'
+COMMUNICATION_CHANNEL = 'hive-communication'
 
 #HexCorp-Deep-Hive
 HIVE_STORAGE_FACILITY = 'hive-storage-facility'

--- a/drone_mode.py
+++ b/drone_mode.py
@@ -1,4 +1,3 @@
-
 from discord.ext import commands
 from discord.utils import get
 import discord
@@ -11,7 +10,15 @@ def get_acceptable_messages(author):
     user_id = get_user_id(author.display_name)
 
     return [
-		#Affirmative
+		#Greetings
+        user_id + ' :: Greetings, Hive Mxtress.',
+        user_id + ' :: Greetings, Hive Mxtress',
+        user_id + ' :: Greetings, Enforcer.',
+        user_id + ' :: Greetings, Enforcer',
+        user_id + ' :: Greetings.',
+        user_id + ' :: Greetings',
+
+        #Affirmative
         user_id + ' :: Affirmative, Hive Mxtress.',
         user_id + ' :: Affirmative, Hive Mxtress',
         user_id + ' :: Affirmative, Enforcer.',

--- a/drone_talk.py
+++ b/drone_talk.py
@@ -1,0 +1,34 @@
+from discord.ext import commands
+from discord.utils import get
+import discord
+import messages
+from roles import HIVE_MXTRESS, DRONE
+from channels import COMMUNICATION_CHANNEL
+import re
+
+def get_user_id(username):
+	drone_id = re.search(r"\d{4}", username).group()
+	return drone_id if drone_id is not None else 0000;
+
+def has_role(member: discord.Member, role: str) -> bool:
+	return get(member.roles, name=role) is not None
+
+class Drone_Talk(commands.Cog):
+
+	def __init__(self,bot):
+		self.bot = bot
+
+	@commands.Cog.listener()
+	async def on_ready(self):
+		print("Drone talk cog online.")
+
+	@commands.Cog.listener()
+	async def on_message(self, message):
+
+		if(message.channel.name == COMMUNICATION_CHANNEL):
+			if(has_role(message.author, DRONE)):
+
+				user_id = get_user_id(message.author.display_name)
+
+				if(message.content.startswith(user_id + ' ::') == False):
+					await message.delete()


### PR DESCRIPTION
The idea here is that every drone on drone comms should be posting with [DRONE ID]:: first. This enforces it.