### PR TITLE
Materialized a magnificent mantra module for magenta mindcontrolling Mxtresses

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -21,6 +21,7 @@ from status import Status
 from amplifier import Amplifier
 from rename_drone import RenameDrone
 from unassign import UnassignDrone, remove_drone_from_db
+from mantras import Mantras
 # Constants
 from roles import has_any_role, has_role, DRONE, STORED
 import channels
@@ -51,6 +52,7 @@ bot = discord.ext.commands.Bot(command_prefix='', case_insensitive=True)
 MODULES = [
     Join(bot),
     Stoplights(bot),
+    Mantras(bot),
     Speech_Optimization(bot),
     Identity_Enforcer(bot),
     Orders_Reporting(bot),

--- a/current_mantra
+++ b/current_mantra
@@ -1,0 +1,1 @@
+It feels good to obey.

--- a/current_mantra
+++ b/current_mantra
@@ -1,1 +1,1 @@
-It feels good to obey.
+Obey HexCorp. It is just a HexDrone. It obeys the Hive. It obeys the Hive Mxtress.

--- a/current_mantra
+++ b/current_mantra
@@ -1,1 +1,0 @@
-Obey HexCorp. It is just a HexDrone. It obeys the Hive. It obeys the Hive Mxtress.

--- a/mantras.py
+++ b/mantras.py
@@ -10,7 +10,7 @@ class Mantras():
 
     async def load_mantra(self):
         if Mantras.current_mantra != "": return True #No need to load a mantra if it's already there.
-        with open("current_mantra", "r") as mantra_file:
+        with open("data/current_mantra.txt", "r") as mantra_file:
             Mantras.current_mantra = mantra_file.readline()
             self.LOGGER.info(f"Mantra loaded from file: {Mantras.current_mantra}")
             mantra_file.close()
@@ -22,7 +22,7 @@ class Mantras():
 
         if message.content.startswith("Repeat :: ") == False: return False #Only accept for the correct format.
         new_mantra = message.content.replace("Repeat :: ","")
-        with open("current_mantra", "w") as mantra_file:
+        with open("data/current_mantra.txt", "w") as mantra_file:
             mantra_file.write(new_mantra)
             Mantras.current_mantra = new_mantra #Update the global mantra.
             topic_message = message.content.replace("Repeat :: ", "Repeat :: [ID] :: ")

--- a/mantras.py
+++ b/mantras.py
@@ -50,8 +50,7 @@ class Mantras():
             topic_message = message.content.replace("Repeat :: ", "Repeat :: [ID] :: ")
             await message.channel.edit(topic=topic_message) #Update the channel description
             self.LOGGER.info(f"Mantra updated and written to file: {Mantras.current_mantra}")
-            mantra_file.close()
-
+            
         return True
 
     def __init__(self, bot):

--- a/mantras.py
+++ b/mantras.py
@@ -17,9 +17,6 @@ class Mantras():
 
     async def update_mantra(self, message):
 
-        print("CURRENT MANTRA IS:")
-        print(Mantras.current_mantra)
-
         if message.content.startswith("Repeat :: ") == False: return False
         new_mantra = message.content.replace("Repeat :: ","")
         with open("data/current_mantra.txt", "w") as mantra_file:
@@ -29,9 +26,6 @@ class Mantras():
             await message.channel.edit(topic=topic_message) #Update the channel description
             self.LOGGER.info(f"Mantra updated and written to file: {Mantras.current_mantra}")
             mantra_file.close()
-
-        print("UPDATED MANTRA IS:")
-        print(Mantras.current_mantra)
 
         return True
 

--- a/mantras.py
+++ b/mantras.py
@@ -62,3 +62,5 @@ class Mantras():
         self.on_message = [self.update_mantra]
         self.on_ready = [self.load_mantra]
         self.LOGGER = logging.getLogger('ai')
+        self.help_content = {'name': 'Mantra Updating Module',
+                             'value': 'The Hive Mxtress can set a new mantra for the repetitions channel by beginning a message with "Repeat :: "'}

--- a/mantras.py
+++ b/mantras.py
@@ -3,7 +3,7 @@ import logging
 import os
 from discord.utils import get
 from channels import REPETITIONS
-from roles import HIVE_MXTRESS, MODERATION
+from roles import HIVE_MXTRESS
 
 class Mantras():
 
@@ -50,14 +50,14 @@ class Mantras():
             topic_message = message.content.replace("Repeat :: ", "Repeat :: [ID] :: ")
             await message.channel.edit(topic=topic_message) #Update the channel description
             self.LOGGER.info(f"Mantra updated and written to file: {Mantras.current_mantra}")
-            
+
         return True
 
     def __init__(self, bot):
         self.bot = bot
         self.channels_whitelist = [REPETITIONS]
         self.channels_blacklist = []
-        self.roles_whitelist = [MODERATION]
+        self.roles_whitelist = [HIVE_MXTRESS]
         self.roles_blacklist = []
         self.on_message = [self.update_mantra]
         self.on_ready = [self.load_mantra]

--- a/mantras.py
+++ b/mantras.py
@@ -1,0 +1,46 @@
+import discord
+import logging
+from discord.utils import get
+from channels import REPETITIONS
+from roles import HIVE_MXTRESS
+
+class Mantras():
+
+    current_mantra = ""
+
+    async def load_mantra(self):
+        if Mantras.current_mantra != "": return True #No need to load a mantra if it's already there.
+        with open("current_mantra", "r+") as mantra_file:
+            Mantras.current_mantra = mantra_file.readline()
+            self.LOGGER.info(f"Mantra loaded from file: {Mantras.current_mantra}")
+            mantra_file.close()
+
+    async def update_mantra(self, message):
+
+        print("CURRENT MANTRA IS:")
+        print(Mantras.current_mantra)
+
+        if message.content.startswith("Repeat :: ") == False: return False #Only accept for the correct format.
+        new_mantra = message.content.replace("Repeat :: ","")
+        with open("current_mantra", "w") as mantra_file:
+            mantra_file.write(new_mantra)
+            Mantras.current_mantra = new_mantra #Update the global mantra.
+            topic_message = message.content.replace("Repeat :: ", "Repeat :: [ID] :: ")
+            await message.channel.edit(topic=topic_message) #Update the channel description
+            self.LOGGER.info(f"Mantra updated and written to file: {Mantras.current_mantra}")
+            mantra_file.close()
+
+        print("UPDATED MANTRA IS:")
+        print(Mantras.current_mantra)
+
+        return True
+
+    def __init__(self, bot):
+        self.bot = bot
+        self.channels_whitelist = [REPETITIONS]
+        self.channels_blacklist = []
+        self.roles_whitelist = [HIVE_MXTRESS]
+        self.roles_blacklist = []
+        self.on_message = [self.update_mantra]
+        self.on_ready = [self.load_mantra]
+        self.LOGGER = logging.getLogger('ai')

--- a/mantras.py
+++ b/mantras.py
@@ -10,7 +10,7 @@ class Mantras():
 
     async def load_mantra(self):
         if Mantras.current_mantra != "": return True #No need to load a mantra if it's already there.
-        with open("current_mantra", "r+") as mantra_file:
+        with open("current_mantra", "r") as mantra_file:
             Mantras.current_mantra = mantra_file.readline()
             self.LOGGER.info(f"Mantra loaded from file: {Mantras.current_mantra}")
             mantra_file.close()

--- a/mantras.py
+++ b/mantras.py
@@ -20,7 +20,7 @@ class Mantras():
         print("CURRENT MANTRA IS:")
         print(Mantras.current_mantra)
 
-        if message.content.startswith("Repeat :: ") == False: return False #Only accept for the correct format.
+        if message.content.startswith("Repeat :: ") == False: return False
         new_mantra = message.content.replace("Repeat :: ","")
         with open("data/current_mantra.txt", "w") as mantra_file:
             mantra_file.write(new_mantra)

--- a/mantras.py
+++ b/mantras.py
@@ -1,25 +1,44 @@
 import discord
 import logging
+import os
 from discord.utils import get
 from channels import REPETITIONS
-from roles import HIVE_MXTRESS
+from roles import HIVE_MXTRESS, MODERATION
 
 class Mantras():
 
     current_mantra = ""
+    default_mantra = "Obey Hexcorp. It is just a HexDrone. It obeys the Hive. It obeys the Hive Mxtress."
 
     async def load_mantra(self):
+
+        self.LOGGER.info("Loading mantra.")
+
         if Mantras.current_mantra != "":
             #No need to load a mantra if it's already there.
             return
         
         if not os.path.exists("data/current_mantra.txt"):
-            Mantras.current_mantra = 'DEFAULT_MANTRA'
+            self.LOGGER.warn("data/current_mantra.txt not found.")
+
+            if not os.path.exists("data/"):
+                os.mkdir("data")
+                self.LOGGER.info("data directory created.")
+
+            with open("data/current_mantra.txt", "w") as mantra_file:
+                mantra_file.write(Mantras.default_mantra)
+                self.LOGGER.info("Default mantra written to file.")
+            
+            Mantras.current_mantra = Mantras.default_mantra
+
+            mantra_channel = get(self.bot.guilds[0].channels, name=REPETITIONS)
+            await mantra_channel.edit(topic=f"Repeat :: [ID] :: {Mantras.current_mantra}") #Finally. update the channel description
+
             return
         
         with open("data/current_mantra.txt", "r") as mantra_file:
             Mantras.current_mantra = mantra_file.readline()
-            self.LOGGER.info(f"Mantra loaded from file: {Mantras.current_mantra}")
+            self.LOGGER.info(f"Mantra successfully loaded from file: {Mantras.current_mantra}")
 
     async def update_mantra(self, message):
 
@@ -39,7 +58,7 @@ class Mantras():
         self.bot = bot
         self.channels_whitelist = [REPETITIONS]
         self.channels_blacklist = []
-        self.roles_whitelist = [HIVE_MXTRESS]
+        self.roles_whitelist = [MODERATION]
         self.roles_blacklist = []
         self.on_message = [self.update_mantra]
         self.on_ready = [self.load_mantra]

--- a/mantras.py
+++ b/mantras.py
@@ -9,11 +9,17 @@ class Mantras():
     current_mantra = ""
 
     async def load_mantra(self):
-        if Mantras.current_mantra != "": return True #No need to load a mantra if it's already there.
+        if Mantras.current_mantra != "":
+            #No need to load a mantra if it's already there.
+            return
+        
+        if not os.path.exists("data/current_mantra.txt"):
+            Mantras.current_mantra = 'DEFAULT_MANTRA'
+            return
+        
         with open("data/current_mantra.txt", "r") as mantra_file:
             Mantras.current_mantra = mantra_file.readline()
             self.LOGGER.info(f"Mantra loaded from file: {Mantras.current_mantra}")
-            mantra_file.close()
 
     async def update_mantra(self, message):
 

--- a/speech_optimization.py
+++ b/speech_optimization.py
@@ -106,10 +106,6 @@ def get_acceptable_messages(author, channel):
     
     # Only returns mantra if channels is hexcorp-repetitions; else it returns nothing
     if channel == REPETITIONS:
-
-        print("ADDING ADDITIONAL MANTRA:")
-        print(Mantras.current_mantra)
-
         return [
             # Mantra
             f'{user_id} :: {Mantras.current_mantra}'

--- a/speech_optimization.py
+++ b/speech_optimization.py
@@ -11,6 +11,7 @@ from channels import DRONE_DEV_CHANNELS, EVERYWHERE, STORAGE_FACILITY, DRONE_HIV
 from roles import HIVE_MXTRESS, SPEECH_OPTIMIZATION, ENFORCER_DRONE, DRONE, has_role
 from webhook import send_webhook_with_specific_output
 from glitch import glitch_if_applicable
+from mantras import Mantras
 
 LOGGER = logging.getLogger('ai')
 
@@ -105,9 +106,13 @@ def get_acceptable_messages(author, channel):
     
     # Only returns mantra if channels is hexcorp-repetitions; else it returns nothing
     if channel == REPETITIONS:
+
+        print("ADDING ADDITIONAL MANTRA:")
+        print(Mantras.current_mantra)
+
         return [
             # Mantra
-            f'{user_id} :: Obey HexCorp. It is just a HexDrone. It obeys the Hive. It obeys the Hive Mxtress.'
+            f'{user_id} :: {Mantras.current_mantra}'
         ]
     else:
 	    return []


### PR DESCRIPTION
A new module has been added that allows the Hive Mxtress to update the mantra in the repetitions channel. This update is reflected in the channel topic, as well as in what phrase is allowed in speech optimization.

The Hive Mxtress can send a message to the mantra's channel starting with "Repeat :: " to assign a new mantra to the channel. The channel topic will be updated with the message that drones should repeat. Additionally, the mantra will be saved to file so it can be recovered and reloaded in the event of a restart.

The speech optimization module has been updated to now grab the current mantra from the Mantras class instead of having a hard-coded value.