### PR TITLE
Feature/bigtext unit tests

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -75,8 +75,9 @@ async def bigtext(context, sentence):
     '''
     Transforms small text into heckin' chonky text.
     '''
-    if context.channel.name in DRONE_HIVE_CHANNELS:
-        await emote.generate_big_text(context.channel, sentence)
+    if context.channel.name not in DRONE_HIVE_CHANNELS:
+        if (reply := emote.generate_big_text(context.channel, sentence)):
+            await context.send(reply)
 
 
 @bot.command(brief="Hive Mxtress", usage="hc!amplify '[message]', #target-channel-as-mention, drones (one or more IDs).")

--- a/ai/emote.py
+++ b/ai/emote.py
@@ -18,7 +18,7 @@ def clean_sentence(sentence):
     return re.sub(r'<:.*:\d*>', '', sentence)
 
 
-async def generate_big_text(channel: discord.TextChannel, sentence):
+def generate_big_text(channel: discord.TextChannel, sentence):
 
     LOGGER.debug("In generate_big_text function.")
 
@@ -54,9 +54,10 @@ async def generate_big_text(channel: discord.TextChannel, sentence):
 
     if message_length > 0 and message_length <= 2000:
         LOGGER.info(f"Sending big-text message of length {message_length} and content '{sentence}'")
-        await channel.send(f"> {reply}")
+        return f"> {reply}"
     elif message_length > 2000:
         LOGGER.info("big-text message was too long to send.")
-        await channel.send("That message is too long to embiggen.")
+        return None
     else:
         LOGGER.debug("big-text request message contained no acceptable content.")
+        return None

--- a/ai/emote.py
+++ b/ai/emote.py
@@ -3,7 +3,6 @@ import re
 
 import discord
 from discord.utils import get
-from channels import DRONE_HIVE_CHANNELS
 
 LOGGER = logging.getLogger('ai')
 
@@ -14,16 +13,13 @@ exceptional_characters = {' ': 'blank', '/': 'hex_slash', '.': 'hex_dot',
 
 
 def clean_sentence(sentence):
-    # Removes custom emojis (<:name:id>)
-    return re.sub(r'<:.*:\d*>', '', sentence)
+    # Removes custom emojis (<:name:id>) and returns the lowercase version
+    return re.sub(r'<:(.*?):\d{18}>', '', sentence).lower()
 
 
 def generate_big_text(channel: discord.TextChannel, sentence):
 
     LOGGER.debug("In generate_big_text function.")
-
-    if channel.name in DRONE_HIVE_CHANNELS:
-        return  # No fun allowed.
 
     LOGGER.debug("Sanatizing sentence of custom emojis.")
 

--- a/test/test_emote.py
+++ b/test/test_emote.py
@@ -27,14 +27,14 @@ class TestEmote(unittest.TestCase):
 
     @patch("ai.emote.get", return_value=normal_mock_emoji)
     def test_return_none_if_generated_text_too_long(self, mocked_get):
-        self.assertEqual(generate_big_text(TestEmote.mock_channel, "9813 is such a good development drone that i could write about how wonderful they are and the bigtext generator would return none because there are too many good things to say about it"), None)
-        self.assertEqual(generate_big_text(TestEmote.mock_channel, "and since we need to do two tests i'd like to mention that 3287 is also a sweet little thing and 5890 always loves to have it around even when it bullies it by calling it a good drone and making it blush"), None)
+        self.assertIsNone(generate_big_text(TestEmote.mock_channel, "9813 is such a good development drone that i could write about how wonderful they are and the bigtext generator would return none because there are too many good things to say about it"))
+        self.assertIsNone(generate_big_text(TestEmote.mock_channel, "and since we need to do two tests i'd like to mention that 3287 is also a sweet little thing and 5890 always loves to have it around even when it bullies it by calling it a good drone and making it blush"))
 
     @patch("ai.emote.get", return_value=normal_mock_emoji)
     def test_return_none_if_input_contains_no_convertible_material(self, mocked_get):
-        self.assertEqual(generate_big_text(TestEmote.mock_channel, "ʰᵉʷʷᵒˀˀ"), None)
-        self.assertEqual(generate_big_text(TestEmote.mock_channel, "ᵐʷˢᶦᵗᵉʳ_ᵒᵇᵃᵐᵃˀ"), None)
-        self.assertEqual(generate_big_text(TestEmote.mock_channel, "_____"), None)
+        self.assertIsNone(generate_big_text(TestEmote.mock_channel, "ʰᵉʷʷᵒˀˀ"))
+        self.assertIsNone(generate_big_text(TestEmote.mock_channel, "ᵐʷˢᶦᵗᵉʳ_ᵒᵇᵃᵐᵃˀ"))
+        self.assertIsNone(generate_big_text(TestEmote.mock_channel, "_____"))
 
     @patch("ai.emote.get", return_value=normal_mock_emoji)
     def test_generator_removes_custom_emojis_from_input(self, mocked_get):

--- a/test/test_emote.py
+++ b/test/test_emote.py
@@ -6,41 +6,44 @@ from ai.emote import generate_big_text
 
 class TestEmote(unittest.TestCase):
 
-    def test_generate_big_text(self):
+    mock_guild = discord.Guild(data={"id": 5890}, state=None)
 
-        self.maxDiff = 2000
+    normal_mock_emoji = discord.Emoji(guild=mock_guild, state=None, data={"name": "hex_h", "id": 589098133287000006, "require_colons": True, "managed": False})
+    extra_custom_emoji = discord.Emoji(guild=mock_guild, state=None, data={"name": "unnecessary_noise", "id": 216154654256398347, "require_colons": True, "managed": False})
+    double_colon_emoji = discord.Emoji(guild=mock_guild, state=None, data={"name": "hex_dc", "id": 589098133287000006, "require_colons": True, "managed": False})
 
-        mock_channel = discord.TextChannel
-        mock_guild = discord.Guild(data={"id": 5890}, state=None)
-        mock_channel.guild = mock_guild
+    mock_channel = discord.TextChannel
+    mock_channel.guild = mock_guild
+    mock_guild.emojis = [normal_mock_emoji, double_colon_emoji, extra_custom_emoji]
 
-        normal_mock_emoji = discord.Emoji(guild=mock_guild, state=None, data={"name": "hex_h", "id": 589098133287000006, "require_colons": True, "managed": False})
-        double_colon_mock_emoji = discord.Emoji(guild=mock_guild, state=None, data={"name": "hex_dc", "id": 589098133287000006, "require_colons": True, "managed": False})
+    normal_response = f"> {str(normal_mock_emoji)*4}"
 
-        normal_response = f"> {str(normal_mock_emoji)*4}"
+    @patch("ai.emote.get", return_value=normal_mock_emoji)
+    def test_generate_big_text_generates_big_text_normally(self, mocked_get):
 
-        # Mocking get() to always return a valid emoji for Testing Purposes.
-        with patch('ai.emote.get', return_value=normal_mock_emoji):
+        self.assertEqual(generate_big_text(TestEmote.mock_channel, "beep"), TestEmote.normal_response)
+        self.assertEqual(generate_big_text(TestEmote.mock_channel, "boop"), TestEmote.normal_response)
+        self.assertEqual(generate_big_text(TestEmote.mock_channel, "    "), TestEmote.normal_response)
 
-            # Happy path
-            self.assertEqual(generate_big_text(mock_channel, "beep"), normal_response)
-            self.assertEqual(generate_big_text(mock_channel, "boop"), normal_response)
-            self.assertEqual(generate_big_text(mock_channel, "    "), normal_response)
+    @patch("ai.emote.get", return_value=normal_mock_emoji)
+    def test_return_none_if_generated_text_too_long(self, mocked_get):
+        self.assertEqual(generate_big_text(TestEmote.mock_channel, "9813 is such a good development drone that i could write about how wonderful they are and the bigtext generator would return none because there are too many good things to say about it"), None)
+        self.assertEqual(generate_big_text(TestEmote.mock_channel, "and since we need to do two tests i'd like to mention that 3287 is also a sweet little thing and 5890 always loves to have it around even when it bullies it by calling it a good drone and making it blush"), None)
 
-            # Message too long
-            self.assertEqual(generate_big_text(mock_channel, "9813 is such a good development drone that i could write about how wonderful they are and the bigtext generator would return none because there are too many good things to say about it"), None)
-            self.assertEqual(generate_big_text(mock_channel, "and since we need to do two tests i'd like to mention that 3287 is also a sweet little thing and 5890 always loves to have it around even when it bullies it by calling it a good drone and making it blush"), None)
+    @patch("ai.emote.get", return_value=normal_mock_emoji)
+    def test_return_none_if_input_contains_no_convertible_material(self, mocked_get):
+        self.assertEqual(generate_big_text(TestEmote.mock_channel, "ʰᵉʷʷᵒˀˀ"), None)
+        self.assertEqual(generate_big_text(TestEmote.mock_channel, "ᵐʷˢᶦᵗᵉʳ_ᵒᵇᵃᵐᵃˀ"), None)
+        self.assertEqual(generate_big_text(TestEmote.mock_channel, "_____"), None)
 
-            # Message has no valid characters
-            self.assertEqual(generate_big_text(mock_channel, "ʰᵉʷʷᵒˀˀ"), None)
-            self.assertEqual(generate_big_text(mock_channel, "ᵐʷˢᶦᵗᵉʳ_ᵒᵇᵃᵐᵃˀ"), None)
-            self.assertEqual(generate_big_text(mock_channel, "_____"), None)
+    @patch("ai.emote.get", return_value=normal_mock_emoji)
+    def test_generator_removes_custom_emojis_from_input(self, mocked_get):
+        self.assertEqual(generate_big_text(TestEmote.mock_channel, f"{str(TestEmote.extra_custom_emoji)}beep{str(TestEmote.extra_custom_emoji)}"), TestEmote.normal_response)
 
-            # Test that the generate_big_text function cleans out excess custom emoji at the start
-            extra_custom_emoji = discord.Emoji(guild=mock_guild, state=None, data={"name": "unnecessary_noise", "id": 216154654256398347, "require_colons": True, "managed": False})
-            self.assertEqual(generate_big_text(mock_channel, f"{str(extra_custom_emoji)}beep{str(extra_custom_emoji)}"), normal_response)
+    @patch("ai.emote.get", return_value=normal_mock_emoji)
+    def test_generator_converts_input_to_lower_case(self, mocked_get):
+        self.assertEqual(generate_big_text(TestEmote.mock_channel, "BEEP"), generate_big_text(TestEmote.mock_channel, "beep"))
 
-        mock_guild.emojis = [normal_mock_emoji, double_colon_mock_emoji]
-
-        # Double colon functionality (two double colons become one double colon emoji)
-        self.assertEqual(generate_big_text(mock_channel, "::"), f"> {str(double_colon_mock_emoji)}")
+    def test_two_consecutive_colons_are_converted_to_a_single_emoji(self):
+        self.assertEqual(generate_big_text(TestEmote.mock_channel, "::"), f"> {str(TestEmote.double_colon_emoji)}")
+        self.assertEqual(generate_big_text(TestEmote.mock_channel, ":::"), f"> {str(TestEmote.double_colon_emoji)}")

--- a/test/test_emote.py
+++ b/test/test_emote.py
@@ -2,7 +2,6 @@ import unittest
 from unittest.mock import patch
 import discord
 from ai.emote import generate_big_text
-from channels import HIVE_COORDINATION
 
 
 class TestEmote(unittest.TestCase):

--- a/test/test_emote.py
+++ b/test/test_emote.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import patch
 import discord
 from ai.emote import generate_big_text
+from channels import HIVE_COORDINATION
 
 
 class TestEmote(unittest.TestCase):
@@ -14,8 +15,8 @@ class TestEmote(unittest.TestCase):
         mock_guild = discord.Guild(data={"id": 5890}, state=None)
         mock_channel.guild = mock_guild
 
-        normal_mock_emoji = discord.Emoji(guild=mock_guild, state=None, data={"name": "hex_h", "id": 589098133287000006, "require_colons": None, "managed": None})
-        double_colon_mock_emoji = discord.Emoji(guild=mock_guild, state=None, data={"name": "hex_dc", "id": 589098133287000006, "require_colons": None, "managed": None})
+        normal_mock_emoji = discord.Emoji(guild=mock_guild, state=None, data={"name": "hex_h", "id": 589098133287000006, "require_colons": True, "managed": False})
+        double_colon_mock_emoji = discord.Emoji(guild=mock_guild, state=None, data={"name": "hex_dc", "id": 589098133287000006, "require_colons": True, "managed": False})
 
         normal_response = f"> {str(normal_mock_emoji)*4}"
 
@@ -36,7 +37,11 @@ class TestEmote(unittest.TestCase):
             self.assertEqual(generate_big_text(mock_channel, "ᵐʷˢᶦᵗᵉʳ_ᵒᵇᵃᵐᵃˀ"), None)
             self.assertEqual(generate_big_text(mock_channel, "_____"), None)
 
+            # Test that the generate_big_text function cleans out excess custom emoji at the start
+            extra_custom_emoji = discord.Emoji(guild=mock_guild, state=None, data={"name": "unnecessary_noise", "id": 216154654256398347, "require_colons": True, "managed": False})
+            self.assertEqual(generate_big_text(mock_channel, f"{str(extra_custom_emoji)}beep{str(extra_custom_emoji)}"), normal_response)
+
         mock_guild.emojis = [normal_mock_emoji, double_colon_mock_emoji]
 
         # Double colon functionality (two double colons become one double colon emoji)
-        self.assertEqual(generate_big_text(mock_channel, "::"), f"> {str(double_colon_mock_emoji)}")    
+        self.assertEqual(generate_big_text(mock_channel, "::"), f"> {str(double_colon_mock_emoji)}")

--- a/test/test_emote.py
+++ b/test/test_emote.py
@@ -1,0 +1,42 @@
+import unittest
+from unittest.mock import patch
+import discord
+from ai.emote import generate_big_text
+
+
+class TestEmote(unittest.TestCase):
+
+    def test_generate_big_text(self):
+
+        self.maxDiff = 2000
+
+        mock_channel = discord.TextChannel
+        mock_guild = discord.Guild(data={"id": 5890}, state=None)
+        mock_channel.guild = mock_guild
+
+        normal_mock_emoji = discord.Emoji(guild=mock_guild, state=None, data={"name": "hex_h", "id": 589098133287000006, "require_colons": None, "managed": None})
+        double_colon_mock_emoji = discord.Emoji(guild=mock_guild, state=None, data={"name": "hex_dc", "id": 589098133287000006, "require_colons": None, "managed": None})
+
+        normal_response = f"> {str(normal_mock_emoji)*4}"
+
+        # Mocking get() to always return a valid emoji for Testing Purposes.
+        with patch('ai.emote.get', return_value=normal_mock_emoji):
+
+            # Happy path
+            self.assertEqual(generate_big_text(mock_channel, "beep"), normal_response)
+            self.assertEqual(generate_big_text(mock_channel, "boop"), normal_response)
+            self.assertEqual(generate_big_text(mock_channel, "    "), normal_response)
+
+            # Message too long
+            self.assertEqual(generate_big_text(mock_channel, "9813 is such a good development drone that i could write about how wonderful they are and the bigtext generator would return none because there are too many good things to say about it"), None)
+            self.assertEqual(generate_big_text(mock_channel, "and since we need to do two tests i'd like to mention that 3287 is also a sweet little thing and 5890 always loves to have it around even when it bullies it by calling it a good drone and making it blush"), None)
+
+            # Message has no valid characters
+            self.assertEqual(generate_big_text(mock_channel, "ʰᵉʷʷᵒˀˀ"), None)
+            self.assertEqual(generate_big_text(mock_channel, "ᵐʷˢᶦᵗᵉʳ_ᵒᵇᵃᵐᵃˀ"), None)
+            self.assertEqual(generate_big_text(mock_channel, "_____"), None)
+
+        mock_guild.emojis = [normal_mock_emoji, double_colon_mock_emoji]
+
+        # Double colon functionality (two double colons become one double colon emoji)
+        self.assertEqual(generate_big_text(mock_channel, "::"), f"> {str(double_colon_mock_emoji)}")    


### PR DESCRIPTION
Added a unit test for the bigtext (emote) module. It tests:
Normal sentence > emote conversion. ("beep" becomes (in emoji) "BEEP")
Sentence too long > returns nothing ("beeeeee[...]eeeeep" returns None)
Sentence with no convertable material > returns nothing ("@@@@" returns None)
Sentence with custom emoji get removed ("[customemoji]BEEP" becomes "BEEP")
Double colon conversion works ("::" becomes (in emoji) "::")

All the tests pass, obviously, and flake8 is happy with my code.
Beep boop.
~~Please let 5890 say fuck.~~