### PR TITLE
Feature/amplifier unit tests

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -89,7 +89,8 @@ async def amplify(context, message: str, target_channel: discord.TextChannel, *d
     if context.channel.name == OFFICE and has_role(context.author, HIVE_MXTRESS):
         target_webhook = await webhook.get_webhook_for_channel(target_channel)
         for amp_profile in amplifier.generate_amplification_information(target_channel, drones):
-            await target_webhook.send(message, username=amp_profile["username"], avatar_url=amp_profile["avatar_url"])
+            if amp_profile is not None:
+                await target_webhook.send(message, username=amp_profile["username"], avatar_url=amp_profile["avatar_url"])
 
 
 @bot.command(aliases=['optimize', 'toggle_speech_op', 'tso'], brief="Hive Mxtress", usage="hc!toggle_speech_optimization @drones (one or more mentions).")

--- a/ai.py
+++ b/ai.py
@@ -20,6 +20,7 @@ import ai.amplifier as amplifier
 import ai.drone_management as drone_management
 import ai.toggle_role as toggle_role
 from ai.mantras import Mantra_Handler
+import webhook
 # Constants
 from roles import has_any_role, has_role, DRONE, STORED, SPEECH_OPTIMIZATION, GLITCHED, HIVE_MXTRESS
 from channels import DRONE_HIVE_CHANNELS, OFFICE, ORDERS_REPORTING, REPETITIONS, BOT_DEV_COMMS
@@ -86,7 +87,9 @@ async def amplify(context, message: str, target_channel: discord.TextChannel, *d
     Allows the Hive Mxtress to speak through other drones.
     '''
     if context.channel.name == OFFICE and has_role(context.author, HIVE_MXTRESS):
-        await amplifier.amplify_message(context, message, target_channel, drones)
+        target_webhook = await webhook.get_webhook_for_channel(target_channel)
+        for amp_profile in amplifier.generate_amplification_information(target_channel, drones):
+            await target_webhook.send(message, username=amp_profile["username"], avatar_url=amp_profile["avatar_url"])
 
 
 @bot.command(aliases=['optimize', 'toggle_speech_op', 'tso'], brief="Hive Mxtress", usage="hc!toggle_speech_optimization @drones (one or more mentions).")

--- a/ai/amplifier.py
+++ b/ai/amplifier.py
@@ -16,17 +16,14 @@ def generate_amplification_information(target_channel, drones):
         LOGGER.debug(f"Preparing drone {drone} for amplification.")
 
         if not re.match(r"\d{4}", drone):
-            print("Not a drone ID.")
             yield None  # Skip any non-drone IDs.
 
         LOGGER.debug("Getting discord ID from database.")
         if (drone_from_db := get_discord_id_of_drone(drone)) is None:
-            print("Not found in DB.")
             yield None  # Given drone does not exist on server.
 
         amplifier_drone = target_channel.guild.get_member(drone_from_db.id)
         if amplifier_drone is None:
-            print("Couldn't get member from guild.")
             yield None  # If getting the member somehow failed (which it really shouldn't), keep calm and carry on.
 
         # Set the avatar URL as appropriate.

--- a/ai/amplifier.py
+++ b/ai/amplifier.py
@@ -1,16 +1,14 @@
 import logging
 import re
-import discord
 from db.drone_dao import get_discord_id_of_drone
 from channels import DRONE_HIVE_CHANNELS
 from roles import ENFORCER_DRONE, has_role
 from resources import DRONE_AVATAR, ENFORCER_AVATAR
-from webhook import get_webhook_for_channel
 
 LOGGER = logging.getLogger('ai')
 
 
-async def amplify_message(context, amplification_message: str, target_channel: discord.TextChannel, drones):
+def generate_amplification_information(target_channel, drones):
     LOGGER.info("Amplifying message.")
 
     for drone in drones:
@@ -18,18 +16,17 @@ async def amplify_message(context, amplification_message: str, target_channel: d
         LOGGER.debug(f"Preparing drone {drone} for amplification.")
 
         if not re.match(r"\d{4}", drone):
-            continue  # Skip non-drone IDs.
+            continue  # Skip any non-drone IDs.
 
         LOGGER.debug("Getting discord ID from database.")
         if (drone_from_db := get_discord_id_of_drone(drone)) is None:
             continue  # Given drone does not exist on server.
 
-        amplifier_drone = context.guild.get_member(drone_from_db.id)
+        amplifier_drone = target_channel.guild.get_member(drone_from_db.id)
         if amplifier_drone is None:
-            continue  # If getting the member somehow failed, keep calm and carry on.
+            continue  # If getting the member somehow failed (which it really shouldn't), keep calm and carry on.
 
-        webhook = await get_webhook_for_channel(target_channel)
-
+        # Set the avatar URL as appropriate.
         amplification_avatar = amplifier_drone.avatar_url
         if target_channel.name in DRONE_HIVE_CHANNELS:
             if has_role(amplifier_drone, ENFORCER_DRONE):
@@ -37,7 +34,4 @@ async def amplify_message(context, amplification_message: str, target_channel: d
             else:
                 amplification_avatar = DRONE_AVATAR
 
-        LOGGER.debug(f"Amplifying message with unit {drone}")
-        await webhook.send(content=f"{drone} :: {amplification_message}",
-                           username=amplifier_drone.display_name,
-                           avatar_url=amplification_avatar)
+        yield {"username": amplifier_drone.display_name, "avatar_url": amplification_avatar}

--- a/ai/amplifier.py
+++ b/ai/amplifier.py
@@ -11,19 +11,27 @@ LOGGER = logging.getLogger('ai')
 def generate_amplification_information(target_channel, drones):
     LOGGER.info("Amplifying message.")
 
+    print(target_channel)
+    print(drones)
+
     for drone in drones:
+
+        print("Iterating")
 
         LOGGER.debug(f"Preparing drone {drone} for amplification.")
 
         if not re.match(r"\d{4}", drone):
+            print("Not a drone ID.")
             continue  # Skip any non-drone IDs.
 
         LOGGER.debug("Getting discord ID from database.")
         if (drone_from_db := get_discord_id_of_drone(drone)) is None:
+            print("Not found in DB.")
             continue  # Given drone does not exist on server.
 
         amplifier_drone = target_channel.guild.get_member(drone_from_db.id)
         if amplifier_drone is None:
+            print("Couldn't get member from guild.")
             continue  # If getting the member somehow failed (which it really shouldn't), keep calm and carry on.
 
         # Set the avatar URL as appropriate.

--- a/ai/amplifier.py
+++ b/ai/amplifier.py
@@ -11,28 +11,23 @@ LOGGER = logging.getLogger('ai')
 def generate_amplification_information(target_channel, drones):
     LOGGER.info("Amplifying message.")
 
-    print(target_channel)
-    print(drones)
-
     for drone in drones:
-
-        print("Iterating")
 
         LOGGER.debug(f"Preparing drone {drone} for amplification.")
 
         if not re.match(r"\d{4}", drone):
             print("Not a drone ID.")
-            continue  # Skip any non-drone IDs.
+            yield None  # Skip any non-drone IDs.
 
         LOGGER.debug("Getting discord ID from database.")
         if (drone_from_db := get_discord_id_of_drone(drone)) is None:
             print("Not found in DB.")
-            continue  # Given drone does not exist on server.
+            yield None  # Given drone does not exist on server.
 
         amplifier_drone = target_channel.guild.get_member(drone_from_db.id)
         if amplifier_drone is None:
             print("Couldn't get member from guild.")
-            continue  # If getting the member somehow failed (which it really shouldn't), keep calm and carry on.
+            yield None  # If getting the member somehow failed (which it really shouldn't), keep calm and carry on.
 
         # Set the avatar URL as appropriate.
         amplification_avatar = amplifier_drone.avatar_url

--- a/test/test_amplifier.py
+++ b/test/test_amplifier.py
@@ -1,29 +1,32 @@
 import discord
 import unittest
 import ai.amplifier as amp
-from unittest.mock import patch
+from unittest.mock import patch, PropertyMock, Mock
 from channels import REPETITIONS
 from db.data_objects import Drone
+
+mocked_drone = Drone(id="5890")
+
+mocked_member = discord.Member
+mocked_member.display_name = "heck drone 5890"
+
+test_guild = Mock()
+test_guild.get_member.return_value = mocked_member
+
+test_channel = PropertyMock()
+test_channel.guild = test_guild
+test_channel.name = REPETITIONS
 
 
 class AmplifierTest(unittest.TestCase):
 
-    mocked_drone = Drone(id="5890")
-    mocked_member = discord.Member
-    mocked_member.display_name = "heck drone 5890"
-
-    test_guild = discord.Guild(data={"id": 5890}, state=None)
-
-    test_channel = discord.TextChannel(guild=test_guild, state=None, data={"id": 5891, "type": "i 'unno", "name": REPETITIONS, "position": "way at the top"})
-
-    
-
     @patch("ai.amplifier.get_discord_id_of_drone", return_value=mocked_drone)
-    def test_amplifier_generator_returns_drones(self, mocked_dao, mocked_discord):
-        
+    @patch("ai.amplifier.has_role", return_value=False)
+    def test_amplifier_generator_returns_drones(self, mocked_dao, mocked_get):
+
         print("Boop beep.")
 
-        for amp_drone in amp.generate_amplification_information(AmplifierTest.test_channel, ["5890"]):
+        for amp_drone in amp.generate_amplification_information(test_channel, ["5890"]):
             print(amp_drone)
 
         print("Beep boop.")

--- a/test/test_amplifier.py
+++ b/test/test_amplifier.py
@@ -1,0 +1,29 @@
+import discord
+import unittest
+import ai.amplifier as amp
+from unittest.mock import patch
+from channels import REPETITIONS
+from db.data_objects import Drone
+
+
+class AmplifierTest(unittest.TestCase):
+
+    mocked_drone = Drone(id="5890")
+    mocked_member = discord.Member
+    mocked_member.display_name = "heck drone 5890"
+
+    test_guild = discord.Guild(data={"id": 5890}, state=None)
+
+    test_channel = discord.TextChannel(guild=test_guild, state=None, data={"id": 5891, "type": "i 'unno", "name": REPETITIONS, "position": "way at the top"})
+
+    
+
+    @patch("ai.amplifier.get_discord_id_of_drone", return_value=mocked_drone)
+    def test_amplifier_generator_returns_drones(self, mocked_dao, mocked_discord):
+        
+        print("Boop beep.")
+
+        for amp_drone in amp.generate_amplification_information(AmplifierTest.test_channel, ["5890"]):
+            print(amp_drone)
+
+        print("Beep boop.")


### PR DESCRIPTION
The amplifier module has been refactored from a "thing that proxies messages based on a list" into a generator. Now, it generates amplification profiles (with a username and avatar) based on a given list of string drone IDs. This was done to seperate discord.py logic from our operational logic as much as possible. But tbh mocking is so GOSH DANG powerful we could probably just go pog wild and not seperate it anyway. But that's not a discussion to have on this PR.

Tests added:
- The generator returns a list of dictionaries when you give it drone IDs.
- The generator returns dictionaries where the avatar_url is the drone avatar if the channel name is in the list of Hive channels.
- The generator yields None if you give it an invalid drone ID (not \d{4}, not found in database, found in database but not on server (somehow)).

Beep boop beep boop. It feels good to obey.