### PR TITLE
Feature/id to member bot util

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -20,16 +20,18 @@ import ai.amplifier as amplifier
 import ai.drone_management as drone_management
 import ai.toggle_role as toggle_role
 from ai.mantras import Mantra_Handler
+# Utils
+from bot_utils import get_id
+import id_converter
+# Database
+from db import database
+from db import drone_dao
 # Constants
 from roles import has_any_role, has_role, DRONE, STORED, SPEECH_OPTIMIZATION, GLITCHED, HIVE_MXTRESS
 from channels import DRONE_HIVE_CHANNELS, OFFICE, ORDERS_REPORTING, REPETITIONS, BOT_DEV_COMMS
-from bot_utils import get_id
 from resources import DRONE_AVATAR, HIVE_MXTRESS_AVATAR, HEXCORP_AVATAR
 
-from db import database
-from db import drone_dao
-
-# set up logging
+# Logging setup
 log_file_handler = handlers.TimedRotatingFileHandler(
     filename='ai.log', encoding='utf-8', backupCount=6, when='D', interval=7)
 log_file_handler.setFormatter(logging.Formatter(
@@ -43,7 +45,7 @@ root_logger.addHandler(log_file_handler)
 LOGGER = logging.getLogger('ai')
 LOGGER.setLevel(logging.DEBUG)
 
-# prepare database
+# Prepare database
 database.prepare()
 
 # Setup bot
@@ -94,8 +96,11 @@ async def toggle_speech_optimization(context, *drones):
     '''
     Lets the Hive Mxtress or trusted users toggle drone speech optimization.
     '''
+
+    member_drones = id_converter.convert_ids_to_members(context.guild, drones)
+
     if has_role(context.author, HIVE_MXTRESS):
-        await toggle_role.toggle_role(context, drones, SPEECH_OPTIMIZATION)
+        await toggle_role.toggle_role(context, member_drones + context.message.mentions, SPEECH_OPTIMIZATION)
 
 
 @bot.command(aliases=['glitch', 'tdg'], brief="Hive Mxtress", usage="hc!toggle_drone_glitch @drones (one or more mentions).")
@@ -103,8 +108,11 @@ async def toggle_drone_glitch(context, *drones):
     '''
     Lets the Hive Mxtress or trusted users toggle drone glitch levels.
     '''
+
+    member_drones = id_converter.convert_ids_to_members(context.guild, drones)
+
     if has_role(context.author, HIVE_MXTRESS):
-        await toggle_role.toggle_role(context, drones, GLITCHED)
+        await toggle_role.toggle_role(context, member_drones + context.message.mentions, GLITCHED)
 
 
 @bot.command(usage="hc!unassign 0000")

--- a/ai.py
+++ b/ai.py
@@ -104,7 +104,7 @@ async def toggle_speech_optimization(context, *drones):
     member_drones = id_converter.convert_ids_to_members(context.guild, drones)
 
     if has_role(context.author, HIVE_MXTRESS):
-        await toggle_role.toggle_role(context, member_drones + context.message.mentions, SPEECH_OPTIMIZATION)
+        await toggle_role.toggle_role(context, member_drones | set(context.message.mentions), SPEECH_OPTIMIZATION)
 
 
 @bot.command(aliases=['glitch', 'tdg'], brief="Hive Mxtress", usage="hc!toggle_drone_glitch @drones (one or more mentions).")
@@ -116,7 +116,7 @@ async def toggle_drone_glitch(context, *drones):
     member_drones = id_converter.convert_ids_to_members(context.guild, drones)
 
     if has_role(context.author, HIVE_MXTRESS):
-        await toggle_role.toggle_role(context, member_drones + context.message.mentions, GLITCHED)
+        await toggle_role.toggle_role(context, member_drones | set(context.message.mentions), GLITCHED)
 
 
 @bot.command(usage="hc!unassign 0000")

--- a/ai.py
+++ b/ai.py
@@ -20,6 +20,7 @@ import ai.amplifier as amplifier
 import ai.drone_management as drone_management
 import ai.toggle_role as toggle_role
 from ai.mantras import Mantra_Handler
+import webhook
 # Utils
 from bot_utils import get_id
 import id_converter
@@ -88,7 +89,10 @@ async def amplify(context, message: str, target_channel: discord.TextChannel, *d
     Allows the Hive Mxtress to speak through other drones.
     '''
     if context.channel.name == OFFICE and has_role(context.author, HIVE_MXTRESS):
-        await amplifier.amplify_message(context, message, target_channel, drones)
+        target_webhook = await webhook.get_webhook_for_channel(target_channel)
+        for amp_profile in amplifier.generate_amplification_information(target_channel, drones):
+            if amp_profile is not None:
+                await target_webhook.send(message, username=amp_profile["username"], avatar_url=amp_profile["avatar_url"])
 
 
 @bot.command(aliases=['optimize', 'toggle_speech_op', 'tso'], brief="Hive Mxtress", usage="hc!toggle_speech_optimization @drones (one or more mentions).")

--- a/ai/amplifier.py
+++ b/ai/amplifier.py
@@ -1,11 +1,10 @@
 import logging
-import re
 import discord
-from db.drone_dao import get_discord_id_of_drone
 from channels import DRONE_HIVE_CHANNELS
 from roles import ENFORCER_DRONE, has_role
 from resources import DRONE_AVATAR, ENFORCER_AVATAR
 from webhook import get_webhook_for_channel
+from id_converter import convert_id_to_member
 
 LOGGER = logging.getLogger('ai')
 
@@ -17,14 +16,7 @@ async def amplify_message(context, amplification_message: str, target_channel: d
 
         LOGGER.debug(f"Preparing drone {drone} for amplification.")
 
-        if not re.match(r"\d{4}", drone):
-            continue  # Skip non-drone IDs.
-
-        LOGGER.debug("Getting discord ID from database.")
-        if (drone_from_db := get_discord_id_of_drone(drone)) is None:
-            continue  # Given drone does not exist on server.
-
-        amplifier_drone = context.guild.get_member(drone_from_db.id)
+        amplifier_drone = convert_id_to_member(drone)
         if amplifier_drone is None:
             continue  # If getting the member somehow failed, keep calm and carry on.
 

--- a/ai/amplifier.py
+++ b/ai/amplifier.py
@@ -2,7 +2,7 @@ import logging
 from channels import DRONE_HIVE_CHANNELS
 from roles import ENFORCER_DRONE, has_role
 from resources import DRONE_AVATAR, ENFORCER_AVATAR
-import id_converter
+from id_converter import convert_id_to_member
 
 LOGGER = logging.getLogger('ai')
 
@@ -14,7 +14,7 @@ def generate_amplification_information(target_channel, drones):
 
         LOGGER.debug(f"Preparing drone {drone} for amplification.")
 
-        amplifier_drone = id_converter.convert_id_to_member(target_channel.guild, drone)
+        amplifier_drone = convert_id_to_member(target_channel.guild, drone)
         if amplifier_drone is None:
             yield None
 

--- a/ai/toggle_role.py
+++ b/ai/toggle_role.py
@@ -20,6 +20,6 @@ async def toggle_role(context, targets: List[discord.Member], role_name: str):
         else:
             LOGGER.info(f"Adding {role_name} to {target.display_name}")
             await target.add_roles(role)
-            await context.send(f"{role_name} toggled off for {target.display_name}")
+            await context.send(f"{role_name} toggled on for {target.display_name}")
 
     LOGGER.info("All roles added to all targets.")

--- a/id_converter.py
+++ b/id_converter.py
@@ -13,8 +13,6 @@ def convert_ids_to_members(guild: discord.Guild, drone_ids) -> Set[discord.Membe
 
     for drone_id in drone_ids:
         drone_member = convert_id_to_member(guild, drone_id)
-        print("Drone member is:")
-        print(drone_member)
         if drone_member is not None:
             drone_members.add(drone_member)
 

--- a/id_converter.py
+++ b/id_converter.py
@@ -1,0 +1,39 @@
+import discord
+import re
+from db.drone_dao import get_discord_id_of_drone
+from typing import List, Optional
+
+
+def convert_ids_to_members(guild: discord.Guild, drone_ids) -> List[discord.Member]:
+    '''
+    Takes a list of string IDs (e.g "5890", "9813") and returns a list of converted member objects.
+    '''
+
+    drone_members = []
+
+    for drone_id in drone_ids:
+        drone_member = convert_id_to_member(guild, drone_id)
+        print("Drone member is:")
+        print(drone_member)
+        if drone_member is not None:
+            drone_members.append(drone_member)
+
+    return drone_members
+
+
+def convert_id_to_member(guild: discord.Guild, drone_id) -> Optional[discord.Member]:
+    '''
+    Takes a given drone ID (e.g "5890") and returns it as a member object if available.
+    '''
+
+    if not re.match(r"^\d{4}$", drone_id):
+        return None  # Can't match something that isn't a drone ID.
+
+    if (drone_from_db := get_discord_id_of_drone(drone_id)) is None:
+        return None  # Drone not present in DB.
+
+    drone_member = guild.get_member(drone_from_db.id)
+    if drone_member is None:
+        return None  # Drone was present in DB, but is somehow not present in server.
+
+    return drone_member

--- a/id_converter.py
+++ b/id_converter.py
@@ -1,22 +1,22 @@
 import discord
 import re
 from db.drone_dao import get_discord_id_of_drone
-from typing import List, Optional
+from typing import Set, Optional
 
 
-def convert_ids_to_members(guild: discord.Guild, drone_ids) -> List[discord.Member]:
+def convert_ids_to_members(guild: discord.Guild, drone_ids) -> Set[discord.Member]:
     '''
     Takes a list of string IDs (e.g "5890", "9813") and returns a list of converted member objects.
     '''
 
-    drone_members = []
+    drone_members = set()
 
     for drone_id in drone_ids:
         drone_member = convert_id_to_member(guild, drone_id)
         print("Drone member is:")
         print(drone_member)
         if drone_member is not None:
-            drone_members.append(drone_member)
+            drone_members.add(drone_member)
 
     return drone_members
 

--- a/test/test_amplifier.py
+++ b/test/test_amplifier.py
@@ -2,7 +2,6 @@ import unittest
 import ai.amplifier as amp
 from unittest.mock import patch, PropertyMock, Mock
 from channels import REPETITIONS
-from db.data_objects import Drone
 from resources import DRONE_AVATAR
 
 test_guild = Mock()

--- a/test/test_amplifier.py
+++ b/test/test_amplifier.py
@@ -26,15 +26,13 @@ class AmplifierTest(unittest.TestCase):
         # Reset the get_member return values (prevents dirtying context between tests).
         test_guild.get_member.side_effect = [mocked_member_1, mocked_member_2]
 
-    @patch("ai.amplifier.get_discord_id_of_drone", side_effect=[mocked_drone_1, mocked_drone_2])
     @patch("ai.amplifier.has_role", return_value=False)
-    def test_amplifier_generator_returns_profile_dictionaries(self, mocked_dao, mocked_role_check):
+    def test_amplifier_generator_returns_profile_dictionaries(self, mocked_role_check):
         self.assertEqual(next(amp.generate_amplification_information(test_channel, ["0077"]))["username"], "⬡-Drone #0077")
         self.assertEqual(next(amp.generate_amplification_information(test_channel, ["5890"]))["username"], "⬡-Drone #5890")
 
-    @patch("ai.amplifier.get_discord_id_of_drone", side_effect=[mocked_drone_1, mocked_drone_2])
     @patch("ai.amplifier.has_role", return_value=False)
-    def test_amplifier_generator_returns_drone_icons_if_in_hive(self, mocked_dao, mocked_role_check):
+    def test_amplifier_generator_returns_drone_icons_if_in_hive(self, mocked_role_check):
 
         test_channel.name = "NOT A HIVE CHANNEL!!!"
         self.assertNotEqual(next(amp.generate_amplification_information(test_channel, ["0077"]))["avatar_url"], DRONE_AVATAR)

--- a/test/test_amplifier.py
+++ b/test/test_amplifier.py
@@ -7,11 +7,9 @@ from resources import DRONE_AVATAR
 
 test_guild = Mock()
 
-mocked_drone_1 = Drone(id="0077")
 mocked_member_1 = Mock()
 mocked_member_1.display_name = "⬡-Drone #0077"
 
-mocked_drone_2 = Drone(id="5890")
 mocked_member_2 = Mock()
 mocked_member_2.display_name = "⬡-Drone #5890"
 
@@ -27,12 +25,14 @@ class AmplifierTest(unittest.TestCase):
         test_guild.get_member.side_effect = [mocked_member_1, mocked_member_2]
 
     @patch("ai.amplifier.has_role", return_value=False)
-    def test_amplifier_generator_returns_profile_dictionaries(self, mocked_role_check):
+    @patch("ai.amplifier.convert_id_to_member", side_effect=[mocked_member_1, mocked_member_2])
+    def test_amplifier_generator_returns_profile_dictionaries(self, mocked_role_check, mocked_id_converter):
         self.assertEqual(next(amp.generate_amplification_information(test_channel, ["0077"]))["username"], "⬡-Drone #0077")
         self.assertEqual(next(amp.generate_amplification_information(test_channel, ["5890"]))["username"], "⬡-Drone #5890")
 
     @patch("ai.amplifier.has_role", return_value=False)
-    def test_amplifier_generator_returns_drone_icons_if_in_hive(self, mocked_role_check):
+    @patch("ai.amplifier.convert_id_to_member", side_effect=[mocked_member_1, mocked_member_2])
+    def test_amplifier_generator_returns_drone_icons_if_in_hive(self, mocked_role_check, mocked_id_converter):
 
         test_channel.name = "NOT A HIVE CHANNEL!!!"
         self.assertNotEqual(next(amp.generate_amplification_information(test_channel, ["0077"]))["avatar_url"], DRONE_AVATAR)


### PR DESCRIPTION
A new bot utility has been created, it converts any numerical string ("5890","9813","3287") into a discord.Member object if the specified drone is a member of the server.

The "toggle_speech_optimization" and "toggle_drone_glitch" can now take any combination of mentions and written IDs (e.g hc!tso @5890 9813 @3287)

The amplification module has also been updated to use this new converter utility, and the tests were updated to reflect these changes.