### PR TITLE
updated on_error, added on_command_error, both log to file

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -5,7 +5,8 @@ import asyncio
 import logging
 from logging import handlers
 from discord.ext.commands import Bot
-import traceback
+from traceback import TracebackException
+
 # Modules
 import ai.stoplights as stoplights
 import ai.identity_enforcement as identity_enforcement
@@ -251,12 +252,13 @@ async def on_ready():
 @bot.event
 async def on_command_error(context, error):
     LOGGER.error(f"!!! Exception caught in {context.command} command !!!")
-    LOGGER.error(error, exc_info=True, stack_info=True)
+    LOGGER.info("".join(TracebackException(type(error), error, error.__traceback__, limit=None).format(chain=True)))
 
 
 @bot.event
 async def on_error(event, *args, **kwargs):
     LOGGER.error(f'!!! EXCEPTION CAUGHT IN {event} !!!')
-    LOGGER.error(sys.exc_info(), exc_info=True, stack_info=True)
+    error, value, tb = sys.exc_info()
+    LOGGER.info("".join(TracebackException(type(value), value, tb, limit=None).format(chain=True)))
 
 bot.run(sys.argv[1])

--- a/ai.py
+++ b/ai.py
@@ -34,13 +34,13 @@ from channels import DRONE_HIVE_CHANNELS, OFFICE, ORDERS_REPORTING, REPETITIONS,
 from resources import DRONE_AVATAR, HIVE_MXTRESS_AVATAR, HEXCORP_AVATAR
 
 # Logging setup
+formatter = logging.Formatter(fmt='%(asctime)s.%(msecs)03d :: %(levelname)s :: %(message)s', datefmt='%Y-%m-%d :: %H:%M:%S')
+
 log_file_handler = handlers.TimedRotatingFileHandler(
     filename='ai.log', encoding='utf-8', backupCount=6, when='D', interval=7)
-log_file_handler.setFormatter(logging.Formatter(
-    '%(asctime)s:%(levelname)s:%(name)s: %(message)s'))
+log_file_handler.setFormatter(formatter)
 
-logging.basicConfig(
-    format='%(asctime)s:%(levelname)s:%(name)s: %(message)s', level=logging.WARNING)
+logging.basicConfig(level=logging.WARNING)
 root_logger = logging.getLogger()
 root_logger.addHandler(log_file_handler)
 
@@ -254,7 +254,7 @@ async def on_command_error(context, error):
     LOGGER.error(error)
     with open("ai.log", "a") as exception_file:
         traceback.print_exception(type(error), error, error.__traceback__, file=exception_file)
-    traceback.print_exception(type(error), error, error.__traceback__)
+    traceback.print_exception(type(error), error, error.__traceback__, file=sys.stderr)
 
 
 @bot.event
@@ -262,6 +262,6 @@ async def on_error(event, *args, **kwargs):
     LOGGER.error(f'!!! EXCEPTION CAUGHT IN {event} !!!')
     with open("ai.log", "a") as exception_file:
         traceback.print_exc(file=exception_file)
-    traceback.print_exc()
+    traceback.print_exc(file=sys.stderr)
 
 bot.run(sys.argv[1])

--- a/ai.py
+++ b/ai.py
@@ -5,6 +5,7 @@ import asyncio
 import logging
 from logging import handlers
 from discord.ext.commands import Bot
+import traceback
 # Modules
 import ai.stoplights as stoplights
 import ai.identity_enforcement as identity_enforcement
@@ -248,8 +249,19 @@ async def on_ready():
 
 
 @bot.event
+async def on_command_error(context, error):
+    LOGGER.error(f"!!! Exception caught in {context.command} command !!!")
+    LOGGER.error(error)
+    with open("ai.log", "a") as exception_file:
+        traceback.print_exception(type(error), error, error.__traceback__, file=exception_file)
+    traceback.print_exception(type(error), error, error.__traceback__)
+
+
+@bot.event
 async def on_error(event, *args, **kwargs):
-    LOGGER.error(
-        f'Exception encountered while handling message with content [{args[0].content}] in channel [{args[0].channel.name}]', exc_info=True)
+    LOGGER.error(f'!!! EXCEPTION CAUGHT IN {event} !!!')
+    with open("ai.log", "a") as exception_file:
+        traceback.print_exc(file=exception_file)
+    traceback.print_exc()
 
 bot.run(sys.argv[1])

--- a/ai.py
+++ b/ai.py
@@ -251,10 +251,7 @@ async def on_ready():
 @bot.event
 async def on_command_error(context, error):
     LOGGER.error(f"!!! Exception caught in {context.command} command !!!")
-    LOGGER.error(error)
-    with open("ai.log", "a") as exception_file:
-        traceback.print_exception(type(error), error, error.__traceback__, file=exception_file)
-    traceback.print_exception(type(error), error, error.__traceback__, file=sys.stderr)
+    LOGGER.error(error, exc_info=True, stack_info=True)
 
 
 @bot.event

--- a/ai.py
+++ b/ai.py
@@ -260,8 +260,6 @@ async def on_command_error(context, error):
 @bot.event
 async def on_error(event, *args, **kwargs):
     LOGGER.error(f'!!! EXCEPTION CAUGHT IN {event} !!!')
-    with open("ai.log", "a") as exception_file:
-        traceback.print_exc(file=exception_file)
-    traceback.print_exc(file=sys.stderr)
+    LOGGER.error(sys.exc_info(), exc_info=True, stack_info=True)
 
 bot.run(sys.argv[1])


### PR DESCRIPTION
Added new error handlers for on_error (which will handle errors in things such as on_message, on_member_join, on_ready) and on_command_error. Now both handlers will print to stderr as well as logging the exception and included stack trace to file.

I also updated the logger formatter to be more On Brand™️
`2020-08-02 :: 00:46:21.059 :: INFO :: Processing additional commands.`