### PR TITLE
added missing drone IDs to amplification messages

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -97,7 +97,7 @@ async def amplify(context, message: str, target_channel: discord.TextChannel, *d
         target_webhook = await webhook.get_webhook_for_channel(target_channel)
         for amp_profile in amplifier.generate_amplification_information(target_channel, drones):
             if amp_profile is not None:
-                await target_webhook.send(message, username=amp_profile["username"], avatar_url=amp_profile["avatar_url"])
+                await target_webhook.send(f'{amp_profile["id"]} :: {message}', username=amp_profile["username"], avatar_url=amp_profile["avatar_url"])
 
 
 @guild_only()

--- a/ai/amplifier.py
+++ b/ai/amplifier.py
@@ -24,4 +24,4 @@ def generate_amplification_information(target_channel, drones):
 
         LOGGER.info(f"Valid drone ({drone}) found. Yielding amplification profile.")
 
-        yield {"username": amplifier_drone.display_name, "avatar_url": amplification_avatar}
+        yield {"username": amplifier_drone.display_name, "avatar_url": amplification_avatar, "id": drone}

--- a/test/test_amplifier.py
+++ b/test/test_amplifier.py
@@ -25,8 +25,12 @@ class AmplifierTest(unittest.TestCase):
 
     @patch("ai.amplifier.convert_id_to_member", side_effect=[mocked_member_1, mocked_member_2])
     def test_amplifier_generator_returns_profile_dictionaries(self, mocked_id_converter):
-        self.assertEqual(next(amp.generate_amplification_information(test_channel, ["0077"]))["username"], "⬡-Drone #0077")
-        self.assertEqual(next(amp.generate_amplification_information(test_channel, ["5890"]))["username"], "⬡-Drone #5890")
+        first = next(amp.generate_amplification_information(test_channel, ["0077"]))
+        second = next(amp.generate_amplification_information(test_channel, ["5890"]))
+        self.assertEqual(first["username"], "⬡-Drone #0077")
+        self.assertEqual(first["id"], "0077")
+        self.assertEqual(second["username"], "⬡-Drone #5890")
+        self.assertEqual(second["id"], "5890")
 
     @patch("ai.amplifier.convert_id_to_member", side_effect=[mocked_member_1, mocked_member_2])
     def test_amplifier_generator_returns_drone_icons_if_in_hive(self, mocked_id_converter):


### PR DESCRIPTION
Just had to add the ID the beginning of the message.

closes #150 