### PR TITLE
fixed bad status checks

### DIFF
--- a/db/drone_dao.py
+++ b/db/drone_dao.py
@@ -71,12 +71,15 @@ def update_droneOS_parameter(drone: discord.Member, column: str, value: bool):
 
 
 def is_optimized(drone: discord.Member):
-    return bool(fetchone('SELECT optimized FROM drone WHERE id = :discord', {'discord': drone.id})['optimized'])
+    optimized_drone = fetchone('SELECT optimized FROM drone WHERE id = :discord', {'discord': drone.id})
+    return optimized_drone is not None and bool(optimized_drone['optimized'])
 
 
 def is_glitched(drone: discord.Member):
-    return bool(fetchone('SELECT glitched FROM drone WHERE id = :discord', {'discord': drone.id})['glitched'])
+    glitched_drone = fetchone('SELECT glitched FROM drone WHERE id = :discord', {'discord': drone.id})
+    return glitched_drone is not None and bool(glitched_drone['glitched'])
 
 
 def is_prepending_id(drone: discord.Member):
-    return bool(fetchone('SELECT id_prepending FROM drone WHERE id = :discord', {'discord': drone.id})['id_prepending'])
+    prepending_drone = fetchone('SELECT id_prepending FROM drone WHERE id = :discord', {'discord': drone.id})
+    return prepending_drone is not None and bool(prepending_drone['id_prepending'])

--- a/main.py
+++ b/main.py
@@ -153,7 +153,7 @@ async def toggle_speech_optimization(context, *drones):
         channel_webhook = await webhook.get_webhook_for_channel(context.channel)
 
         for drone in member_drones:
-            if drone_dao.is_prepending_id(drone):
+            if drone_dao.is_optimized(drone):
                 drone_dao.update_droneOS_parameter(drone, "optimized", False)
                 await drone.remove_roles(role)
                 await channel_webhook.send(
@@ -185,7 +185,7 @@ async def toggle_drone_glitch(context, *drones):
         channel_webhook = await webhook.get_webhook_for_channel(context.channel)
 
         for drone in member_drones:
-            if drone_dao.is_prepending_id(drone):
+            if drone_dao.is_glitched(drone):
                 drone_dao.update_droneOS_parameter(drone, "glitched", False)
                 await drone.remove_roles(role)
                 await channel_webhook.send(


### PR DESCRIPTION
The `is_optimized` and the other status checking functions raised Errors when the argument was a non-drone. So for example, everytime the Hive Mxtress wanted to use a command.

Also for toggling it always used `is_prepending_id` which made it impossible to properly toggle glitch and optimization