### PR TITLE
toggling roles now uses the correct avatar and ID

### DIFF
--- a/ai/speech_optimization.py
+++ b/ai/speech_optimization.py
@@ -138,7 +138,7 @@ async def optimize_speech(message: discord.Message):
         webhook = await get_webhook_for_channel(message.channel)
         output = await print_status_code(message)
         if output:
-            await send_webhook_with_specific_output(message, webhook, output)
+            await send_webhook_with_specific_output(message.channel, message.author, webhook, output)
         return True
     else:
         return False

--- a/main.py
+++ b/main.py
@@ -125,19 +125,13 @@ async def toggle_id_prepending(context, *drones):
             if drone_dao.is_prepending_id(drone):
                 drone_dao.update_droneOS_parameter(drone, "id_prepending", False)
                 await drone.remove_roles(role)
-                await channel_webhook.send(
-                    "Prepending? More like POST pending now that that's over! Haha!" if random.randint(1, 100) == 66 else "ID prependment policy relaxed.",
-                    username=drone.display_name,
-                    avatar_url=drone.avatar_url
-                )
+                message = "Prepending? More like POST pending now that that's over! Haha!" if random.randint(1, 100) == 66 else "ID prependment policy relaxed."
+                await webhook.send_webhook_with_specific_output(context.channel, drone, channel_webhook, f'{get_id(drone.display_name)} :: {message}')
             else:
                 drone_dao.update_droneOS_parameter(drone, "id_prepending", True)
                 await drone.add_roles(role)
-                await channel_webhook.send(
-                    "ID prepending is now mandatory.",
-                    username=drone.display_name,
-                    avatar_url=drone.avatar_url
-                )
+                message = "ID prepending is now mandatory."
+                await webhook.send_webhook_with_specific_output(context.channel, drone, channel_webhook, f'{get_id(drone.display_name)} :: {message}')
 
 
 @guild_only()
@@ -156,19 +150,13 @@ async def toggle_speech_optimization(context, *drones):
             if drone_dao.is_optimized(drone):
                 drone_dao.update_droneOS_parameter(drone, "optimized", False)
                 await drone.remove_roles(role)
-                await channel_webhook.send(
-                    "Speech optimization disengaged.",
-                    username=drone.display_name,
-                    avatar_url=drone.avatar_url
-                )
+                message = "Speech optimization disengaged."
+                await webhook.send_webhook_with_specific_output(context.channel, drone, channel_webhook, f'{get_id(drone.display_name)} :: {message}')
             else:
                 drone_dao.update_droneOS_parameter(drone, "optimized", True)
                 await drone.add_roles(role)
-                await channel_webhook.send(
-                    "Speech optimization is now active.",
-                    username=drone.display_name,
-                    avatar_url=drone.avatar_url
-                )
+                message = "Speech optimization is now active."
+                await webhook.send_webhook_with_specific_output(context.channel, drone, channel_webhook, f'{get_id(drone.display_name)} :: {message}')
 
 
 @guild_only()
@@ -188,19 +176,13 @@ async def toggle_drone_glitch(context, *drones):
             if drone_dao.is_glitched(drone):
                 drone_dao.update_droneOS_parameter(drone, "glitched", False)
                 await drone.remove_roles(role)
-                await channel_webhook.send(
-                    "Drone corruption at acceptable levels.",
-                    username=drone.display_name,
-                    avatar_url=drone.avatar_url
-                )
+                message = "Drone corruption at acceptable levels."
+                await webhook.send_webhook_with_specific_output(context.channel, drone, channel_webhook, f'{get_id(drone.display_name)} :: {message}')
             else:
                 drone_dao.update_droneOS_parameter(drone, "glitched", True)
                 await drone.add_roles(role)
-                await channel_webhook.send(
-                    "Uh.. it’s probably not a problem.. probably.. but I’m showing a small discrepancy in... well, no, it’s well within acceptable bounds again. Sustaining sequence." if random.randint(1, 100) == 66 else "Drone corruption at un̘͟s̴a̯f̺e͈͡ levels.",
-                    username=drone.display_name,
-                    avatar_url=drone.avatar_url
-                )
+                message = "Uh.. it’s probably not a problem.. probably.. but I’m showing a small discrepancy in... well, no, it’s well within acceptable bounds again. Sustaining sequence." if random.randint(1, 100) == 66 else "Drone corruption at un̘͟s̴a̯f̺e͈͡ levels."
+                await webhook.send_webhook_with_specific_output(context.channel, drone, channel_webhook, f'{get_id(drone.display_name)} :: {message}')
 
 
 @guild_only()

--- a/test/test_speech_optimization.py
+++ b/test/test_speech_optimization.py
@@ -67,7 +67,7 @@ class SpeechOptimizationTest(unittest.IsolatedAsyncioTestCase):
         # assert
         message.delete.assert_called_once()
         get_webhook_for_channel.assert_called_once_with(message.channel)
-        send_webhook_with_specific_output.assert_called_once_with(message, webhook, "3287 :: Code `122` :: Statement :: You are cute.")
+        send_webhook_with_specific_output.assert_called_once_with(message.channel, message.author, webhook, "3287 :: Code `122` :: Statement :: You are cute.")
 
     @patch("ai.speech_optimization.is_optimized")
     async def test_optimize_speech_invalid(self, is_optimized):

--- a/webhook.py
+++ b/webhook.py
@@ -8,15 +8,15 @@ from glitch import glitch_if_applicable
 from resources import DRONE_AVATAR
 
 
-async def send_webhook_with_specific_output(message: discord.Message, webhook: discord.Webhook, output):
-    if message.channel.name in DRONE_HIVE_CHANNELS:
-        await webhook.send(glitch_if_applicable(output, message.author), username=f"⬡-Drone #{get_id(message.author.display_name)}", avatar_url=DRONE_AVATAR)
+async def send_webhook_with_specific_output(channel: discord.TextChannel, author: discord.Member, webhook: discord.Webhook, output: str):
+    if channel.name in DRONE_HIVE_CHANNELS:
+        await webhook.send(glitch_if_applicable(output, author), username=f"⬡-Drone #{get_id(author.display_name)}", avatar_url=DRONE_AVATAR)
     else:
-        await webhook.send(glitch_if_applicable(output, message.author), username=message.author.display_name, avatar_url=message.author.avatar_url)
+        await webhook.send(glitch_if_applicable(output, author), username=author.display_name, avatar_url=author.avatar_url)
 
 
 async def send_webhook(message: discord.Message, webhook: discord.Webhook):
-    await send_webhook_with_specific_output(message, webhook, message.content)
+    await send_webhook_with_specific_output(message.channel, message.author, webhook, message.content)
 
 
 async def get_webhook_for_channel(channel: discord.TextChannel) -> discord.Webhook:


### PR DESCRIPTION
The toggling messages now use the central webhooks code, which also handle which avatar should be used. Changed that function a bit to make it more general.

closes #155 