### PR TITLE
Feature/display names reflect status

### DIFF
--- a/display_names.py
+++ b/display_names.py
@@ -1,19 +1,17 @@
 import discord
 import logging
 from bot_utils import get_id
-from db.drone_dao import is_optimized, is_glitched, is_prepending_id
+from db.drone_dao import is_glitched, is_prepending_id, is_optimized
 
 LOGGER = logging.getLogger("ai")
 
 
 async def update_display_name(user: discord.Member):
     drone_id = get_id(user.display_name)
-    LOGGER.info(f"Optimized: {is_optimized(user)} Glitched: {is_glitched(user)} Prepending: {is_prepending_id(user)}")
     new_display_name = f"{'⬢' if is_optimized(user) or is_glitched(user) or is_prepending_id(user) else '⬡'}-Drone #{drone_id}"
-    LOGGER.info("Updating drone display name.")
-    LOGGER.info(f"Old name: {user.display_name}")
-    LOGGER.info(f"New name: {new_display_name}")
+    LOGGER.info(f"Updating drone display name. Old name: {user.display_name}. New name: {new_display_name}.")
     if user.display_name == new_display_name:
+        # Return false if no update required.
         return False
     await user.edit(nick=new_display_name)
     return True

--- a/display_names.py
+++ b/display_names.py
@@ -1,0 +1,19 @@
+import discord
+import logging
+from bot_utils import get_id
+from db.drone_dao import is_optimized, is_glitched, is_prepending_id
+
+LOGGER = logging.getLogger("ai")
+
+
+async def update_display_name(user: discord.Member):
+    drone_id = get_id(user.display_name)
+    LOGGER.info(f"Optimized: {is_optimized(user)} Glitched: {is_glitched(user)} Prepending: {is_prepending_id(user)}")
+    new_display_name = f"{'⬢' if is_optimized(user) or is_glitched(user) or is_prepending_id(user) else '⬡'}-Drone #{drone_id}"
+    LOGGER.info("Updating drone display name.")
+    LOGGER.info(f"Old name: {user.display_name}")
+    LOGGER.info(f"New name: {new_display_name}")
+    if user.display_name == new_display_name:
+        return False
+    await user.edit(nick=new_display_name)
+    return True

--- a/main.py
+++ b/main.py
@@ -32,6 +32,7 @@ from ai.mantras import Mantra_Handler
 import webhook
 # Utils
 from bot_utils import get_id, COMMAND_PREFIX
+from display_names import update_display_name
 import id_converter
 # Database
 from db import database
@@ -134,11 +135,17 @@ async def toggle_id_prepending(context, *drones):
                 drone_dao.update_droneOS_parameter(drone, "id_prepending", False)
                 await drone.remove_roles(role)
                 message = "Prepending? More like POST pending now that that's over! Haha!" if random.randint(1, 100) == 66 else "ID prependment policy relaxed."
+                if await update_display_name(drone):
+                    # Display name has been updated, get the new drone object
+                    drone = context.guild.get_member(drone.id)
                 await webhook.send_webhook_with_specific_output(context.channel, drone, channel_webhook, f'{get_id(drone.display_name)} :: {message}')
             else:
                 drone_dao.update_droneOS_parameter(drone, "id_prepending", True)
                 await drone.add_roles(role)
                 message = "ID prepending is now mandatory."
+                if await update_display_name(drone):
+                    # Display name has been updated, get the new drone object
+                    drone = context.guild.get_member(drone.id)
                 await webhook.send_webhook_with_specific_output(context.channel, drone, channel_webhook, f'{get_id(drone.display_name)} :: {message}')
 
 
@@ -160,11 +167,17 @@ async def toggle_speech_optimization(context, *drones):
                 drone_dao.update_droneOS_parameter(drone, "optimized", False)
                 await drone.remove_roles(role)
                 message = "Speech optimization disengaged."
+                if await update_display_name(drone):
+                    # Display name has been updated, get the new drone object
+                    drone = context.guild.get_member(drone.id)
                 await webhook.send_webhook_with_specific_output(context.channel, drone, channel_webhook, f'{get_id(drone.display_name)} :: {message}')
             else:
                 drone_dao.update_droneOS_parameter(drone, "optimized", True)
                 await drone.add_roles(role)
                 message = "Speech optimization is now active."
+                if await update_display_name(drone):
+                    # Display name has been updated, get the new drone object
+                    drone = context.guild.get_member(drone.id)
                 await webhook.send_webhook_with_specific_output(context.channel, drone, channel_webhook, f'{get_id(drone.display_name)} :: {message}')
 
 
@@ -187,11 +200,17 @@ async def toggle_drone_glitch(context, *drones):
                 drone_dao.update_droneOS_parameter(drone, "glitched", False)
                 await drone.remove_roles(role)
                 message = "Drone corruption at acceptable levels."
+                if await update_display_name(drone):
+                    # Display name has been updated, get the new drone object
+                    drone = context.guild.get_member(drone.id)
                 await webhook.send_webhook_with_specific_output(context.channel, drone, channel_webhook, f'{get_id(drone.display_name)} :: {message}')
             else:
                 drone_dao.update_droneOS_parameter(drone, "glitched", True)
                 await drone.add_roles(role)
                 message = "Uh.. it’s probably not a problem.. probably.. but I’m showing a small discrepancy in... well, no, it’s well within acceptable bounds again. Sustaining sequence." if random.randint(1, 100) == 66 else "Drone corruption at un̘͟s̴a̯f̺e͈͡ levels."
+                if await update_display_name(drone):
+                    # Display name has been updated, get the new drone object
+                    drone = context.guild.get_member(drone.id)
                 await webhook.send_webhook_with_specific_output(context.channel, drone, channel_webhook, f'{get_id(drone.display_name)} :: {message}')
 
 

--- a/test/test_display_names.py
+++ b/test/test_display_names.py
@@ -1,0 +1,62 @@
+from unittest import IsolatedAsyncioTestCase
+from display_names import update_display_name
+from unittest.mock import AsyncMock, patch
+
+
+class TestDisplayNames(IsolatedAsyncioTestCase):
+
+    @patch("display_names.is_glitched")
+    @patch("display_names.is_optimized")
+    @patch("display_names.is_prepending_id")
+    async def test_display_name_returns_false_when_unoptimized_drone_require_no_updates(self, glitched, optimized, prepending):
+
+        glitched.return_value = False
+        optimized.return_value = False
+        prepending.return_value = False
+
+        mock_user = AsyncMock()
+        mock_user.display_name = "⬡-Drone #5890"
+        self.assertFalse(await update_display_name(mock_user))
+        mock_user.edit.assert_not_called()
+
+    @patch("display_names.is_glitched")
+    @patch("display_names.is_optimized")
+    @patch("display_names.is_prepending_id")
+    async def test_display_name_returns_false_when_optimized_drone_require_no_updates(self, glitched, optimized, prepending):
+
+        glitched.return_value = False
+        optimized.return_value = True
+        prepending.return_value = False
+
+        mock_user = AsyncMock()
+        mock_user.display_name = "⬢-Drone #5890"
+        self.assertFalse(await update_display_name(mock_user))
+        mock_user.edit.assert_not_called()
+
+    @patch("display_names.is_glitched")
+    @patch("display_names.is_optimized")
+    @patch("display_names.is_prepending_id")
+    async def test_display_name_returns_true_and_edits_nick_of_unoptimized_drone_when_updates_required(self, glitched, optimized, prepending):
+
+        glitched.return_value = False
+        optimized.return_value = True
+        prepending.return_value = False
+
+        mock_user = AsyncMock()
+        mock_user.display_name = "⬡-Drone #5890"
+        self.assertTrue(await update_display_name(mock_user))
+        mock_user.edit.assert_called_with(nick="⬢-Drone #5890")
+
+    @patch("display_names.is_glitched")
+    @patch("display_names.is_optimized")
+    @patch("display_names.is_prepending_id")
+    async def test_display_name_returns_true_and_edits_nick_of_optimized_drone_when_updates_required(self, glitched, optimized, prepending):
+
+        glitched.return_value = False
+        optimized.return_value = False
+        prepending.return_value = False
+
+        mock_user = AsyncMock()
+        mock_user.display_name = "⬢-Drone #5890"
+        self.assertTrue(await update_display_name(mock_user))
+        mock_user.edit.assert_called_with(nick="⬡-Drone #5890")


### PR DESCRIPTION
Display names are now updated to reflect a drones general status. If a drone is (at least, or any combination of) optimized, glitched, or has ID prepending enabled, the Hexagon at the start of their name will be filled, otherwise it will be unfilled.

Fixes #178