### PR TITLE
Optimization disabled in mod channels

### DIFF
--- a/ai/speech_optimization.py
+++ b/ai/speech_optimization.py
@@ -2,7 +2,7 @@ import logging
 import re
 import discord
 from bot_utils import get_id
-from channels import REPETITIONS, ORDERS_REPORTING, ORDERS_COMPLETION
+from channels import REPETITIONS, ORDERS_REPORTING, ORDERS_COMPLETION, MODERATION_CHANNEL, MODERATION_LOG
 from roles import SPEECH_OPTIMIZATION, has_role
 from webhook import send_webhook_with_specific_output
 from ai.mantras import Mantra_Handler
@@ -96,7 +96,7 @@ code_map = {
 informative_status_code_regex = re.compile(r'(\d{4}) :: (\d{3}) :: (.*)$')
 plain_status_code_regex = re.compile(r'(\d{4}) :: (\d{3})$')
 
-CHANNEL_BLACKLIST = [ORDERS_REPORTING, ORDERS_COMPLETION]
+CHANNEL_BLACKLIST = [ORDERS_REPORTING, ORDERS_COMPLETION, MODERATION_CHANNEL, MODERATION_LOG]
 
 
 def get_acceptable_messages(author, channel):

--- a/ai/speech_optimization.py
+++ b/ai/speech_optimization.py
@@ -2,7 +2,7 @@ import logging
 import re
 import discord
 from bot_utils import get_id
-from channels import REPETITIONS, ORDERS_REPORTING, ORDERS_COMPLETION, MODERATION_CHANNEL, MODERATION_LOG
+from channels import REPETITIONS, ORDERS_REPORTING, ORDERS_COMPLETION, MODERATION_CHANNEL, MODERATION_LOG, MODERATION_CATEGORY
 from roles import SPEECH_OPTIMIZATION, has_role
 from webhook import send_webhook_with_specific_output
 from ai.mantras import Mantra_Handler
@@ -97,6 +97,7 @@ informative_status_code_regex = re.compile(r'(\d{4}) :: (\d{3}) :: (.*)$')
 plain_status_code_regex = re.compile(r'(\d{4}) :: (\d{3})$')
 
 CHANNEL_BLACKLIST = [ORDERS_REPORTING, ORDERS_COMPLETION, MODERATION_CHANNEL, MODERATION_LOG]
+CATEGORY_BLACKLIST = [MODERATION_CATEGORY]
 
 
 def get_acceptable_messages(author, channel):
@@ -135,7 +136,7 @@ async def optimize_speech(message: discord.Message):
     is_status_code = acceptable_status_code_message and acceptable_status_code_message.group(1) == get_id(message.author.display_name)
     is_acceptable = message.content in get_acceptable_messages(message.author, message.channel.name) or is_status_code
 
-    if is_optimized(message.author) and not is_acceptable and message.channel.name not in CHANNEL_BLACKLIST:
+    if is_optimized(message.author) and not is_acceptable and message.channel.name not in CHANNEL_BLACKLIST and message.channel.category.name not in CATEGORY_BLACKLIST:
         LOGGER.info("Deleting inappropriate message by optimized drone.")
         await message.delete()
         return True

--- a/channels.py
+++ b/channels.py
@@ -3,6 +3,7 @@ OFFICE = 'hex-office'
 MODERATION_CHANNEL = 'moderation-channel'
 
 # Moderation
+MODERATION_CATEGORY = 'moderation'
 MODERATION_LOG = 'moderation-log'
 
 # HexCorp-Induction

--- a/channels.py
+++ b/channels.py
@@ -1,5 +1,9 @@
 # HexCorp Control Tower
 OFFICE = 'hex-office'
+MODERATION_CHANNEL = 'moderation-channel'
+
+# Moderation
+MODERATION_LOG = 'moderation-log'
 
 # HexCorp-Induction
 CONSENT_CHANNEL = 'hexcorp-submission'

--- a/test/test_speech_optimization.py
+++ b/test/test_speech_optimization.py
@@ -134,7 +134,7 @@ class SpeechOptimizationTest(unittest.IsolatedAsyncioTestCase):
 
         # assert
         message.delete.assert_not_called()
-    
+
     @patch("ai.speech_optimization.is_optimized")
     async def test_optimize_speech_in_mod_channel(self, is_optimized):
         # setup

--- a/test/test_speech_optimization.py
+++ b/test/test_speech_optimization.py
@@ -134,3 +134,20 @@ class SpeechOptimizationTest(unittest.IsolatedAsyncioTestCase):
 
         # assert
         message.delete.assert_not_called()
+    
+    @patch("ai.speech_optimization.is_optimized")
+    async def test_optimize_speech_in_mod_channel(self, is_optimized):
+        # setup
+        message = AsyncMock()
+        message.content = "It is a good moderator drone and beep boop"
+        message.author.display_name = "⬡-Drone #9813"
+        message.author.roles = [optimized_role]
+        message.channel.category.name = channels.MODERATION_CATEGORY
+
+        is_optimized.return_value = True
+
+        # run
+        await speech_optimization.optimize_speech(message)
+
+        # assert
+        message.delete.assert_not_called()


### PR DESCRIPTION
Mod channels have been added to the optimization blacklist. It doesn't have access to all the mod channels, but these are the two that it found in the dev server.

Fixes #143.