### PR TITLE
Associates can no longer use status codes

### DIFF
--- a/ai/speech_optimization.py
+++ b/ai/speech_optimization.py
@@ -137,9 +137,6 @@ async def optimize_speech(message: discord.Message):
         LOGGER.info("Deleting inappropriate message by optimized drone.")
         await message.delete()
         return True
-    elif not has_role(message.author, DRONE):
-        LOGGER.info("Ignoring message from non-drone.")
-        return True
     elif (informative_status_code_message or is_status_code) and has_role(message.author, DRONE):
         LOGGER.info("Optimizing speech code for drone.")
         webhook = await get_webhook_for_channel(message.channel)
@@ -148,4 +145,5 @@ async def optimize_speech(message: discord.Message):
             await send_webhook_with_specific_output(message.channel, message.author, webhook, output)
         return True
     else:
+        LOGGER.info("Ignoring message from non-drone.")
         return False

--- a/db/drone_dao.py
+++ b/db/drone_dao.py
@@ -79,6 +79,11 @@ def update_droneOS_parameter(drone: discord.Member, column: str, value: bool):
     # BUT IT'S FINEEEE 'cus the only functions that call this have a preset column value that is never based on user input.
 
 
+def is_drone(member: discord.Member) -> bool:
+    drone = fetchone('SELECT id FROM drone WHERE id = :discord', {'discord': member.id})
+    return drone is not None
+
+
 def is_optimized(drone: discord.Member) -> bool:
     optimized_drone = fetchone('SELECT optimized FROM drone WHERE id = :discord', {'discord': drone.id})
     return optimized_drone is not None and bool(optimized_drone['optimized'])

--- a/test/test_speech_optimization.py
+++ b/test/test_speech_optimization.py
@@ -14,7 +14,6 @@ optimized_role.name = roles.SPEECH_OPTIMIZATION
 
 class SpeechOptimizationTest(unittest.IsolatedAsyncioTestCase):
 
-
     @patch("ai.speech_optimization.is_drone")
     @patch("ai.speech_optimization.is_optimized")
     async def test_print_status_code(self, is_optimized, is_drone):

--- a/test/test_speech_optimization.py
+++ b/test/test_speech_optimization.py
@@ -5,6 +5,9 @@ import roles
 import channels
 import ai.speech_optimization as speech_optimization
 
+drone_role = Mock()
+drone_role.name = roles.DRONE
+
 optimized_role = Mock()
 optimized_role.name = roles.SPEECH_OPTIMIZATION
 
@@ -15,6 +18,7 @@ class SpeechOptimizationTest(unittest.IsolatedAsyncioTestCase):
         # setup
         message = AsyncMock()
         message.content = "9813 :: 050 :: beep boop"
+        message.author.roles = [drone_role]
 
         # run
         response = await speech_optimization.print_status_code(message)
@@ -27,6 +31,7 @@ class SpeechOptimizationTest(unittest.IsolatedAsyncioTestCase):
         # setup
         message = AsyncMock()
         message.content = "9813 :: 050"
+        message.author.roles = [drone_role]
 
         # run
         response = await speech_optimization.print_status_code(message)
@@ -39,9 +44,23 @@ class SpeechOptimizationTest(unittest.IsolatedAsyncioTestCase):
         # setup
         message = AsyncMock()
         message.content = "9813 :: beep boop"
+        message.author.roles = [drone_role]
 
         # run
         response = await speech_optimization.print_status_code(message)
+
+        # assert
+        message.delete.assert_not_called()
+        self.assertFalse(response)
+
+    async def test_print_status_code_from_nondrone(self):
+        # setup
+        message = AsyncMock()
+        message.content = "0000 :: 050"
+        message.author.roles = []
+
+        # run
+        response = await speech_optimization.optimize_speech(message)
 
         # assert
         message.delete.assert_not_called()
@@ -55,7 +74,7 @@ class SpeechOptimizationTest(unittest.IsolatedAsyncioTestCase):
         message = AsyncMock()
         message.content = "3287 :: 122"
         message.author.display_name = "⬡-Drone #3287"
-        message.author.roles = [optimized_role]
+        message.author.roles = [drone_role, optimized_role]
 
         is_optimized.return_value = True
 
@@ -76,7 +95,7 @@ class SpeechOptimizationTest(unittest.IsolatedAsyncioTestCase):
         message = AsyncMock()
         message.content = "It is a cute beep boop"
         message.author.display_name = "⬡-Drone #3287"
-        message.author.roles = [optimized_role]
+        message.author.roles = [drone_role, optimized_role]
 
         is_optimized.return_value = True
 
@@ -92,7 +111,7 @@ class SpeechOptimizationTest(unittest.IsolatedAsyncioTestCase):
         message = AsyncMock()
         message.content = "3287 :: 050 :: All drones are cute~"
         message.author.display_name = "⬡-Drone #3287"
-        message.author.roles = [optimized_role]
+        message.author.roles = [drone_role, optimized_role]
 
         is_optimized.return_value = True
 
@@ -108,7 +127,7 @@ class SpeechOptimizationTest(unittest.IsolatedAsyncioTestCase):
         message = AsyncMock()
         message.content = "It is a cute beep boop"
         message.author.display_name = "⬡-Drone #3287"
-        message.author.roles = []
+        message.author.roles = [drone_role]
 
         is_optimized.return_value = False
 
@@ -124,7 +143,7 @@ class SpeechOptimizationTest(unittest.IsolatedAsyncioTestCase):
         message = AsyncMock()
         message.content = "It will be an adorable drone and beep boop"
         message.author.display_name = "⬡-Drone #3287"
-        message.author.roles = [optimized_role]
+        message.author.roles = [drone_role, optimized_role]
         message.channel.name = channels.ORDERS_REPORTING
 
         is_optimized.return_value = True

--- a/test/test_speech_optimization.py
+++ b/test/test_speech_optimization.py
@@ -14,11 +14,16 @@ optimized_role.name = roles.SPEECH_OPTIMIZATION
 
 class SpeechOptimizationTest(unittest.IsolatedAsyncioTestCase):
 
-    async def test_print_status_code(self):
+    @patch("ai.speech_optimization.is_drone")
+    @patch("ai.speech_optimization.is_optimized")
+    async def test_print_status_code(self, is_optimized, is_drone):
         # setup
         message = AsyncMock()
         message.content = "9813 :: 050 :: beep boop"
         message.author.roles = [drone_role]
+
+        is_drone.return_value = True
+        is_optimized.return_value = False
 
         # run
         response = await speech_optimization.print_status_code(message)
@@ -27,11 +32,14 @@ class SpeechOptimizationTest(unittest.IsolatedAsyncioTestCase):
         message.delete.assert_called_once()
         self.assertEqual(response, "9813 :: Code `050` :: Statement :: beep boop")
 
-    async def test_print_status_code_plain(self):
+    @patch("ai.speech_optimization.is_drone")
+    async def test_print_status_code_plain(self, is_drone):
         # setup
         message = AsyncMock()
         message.content = "9813 :: 050"
         message.author.roles = [drone_role]
+
+        is_drone.return_value = True
 
         # run
         response = await speech_optimization.print_status_code(message)
@@ -73,7 +81,8 @@ class SpeechOptimizationTest(unittest.IsolatedAsyncioTestCase):
     @patch("ai.speech_optimization.is_optimized")
     @patch("ai.speech_optimization.send_webhook_with_specific_output")
     @patch("ai.speech_optimization.get_webhook_for_channel")
-    async def test_optimize_speech(self, get_webhook_for_channel, send_webhook_with_specific_output, is_optimized):
+    @patch("ai.speech_optimization.is_drone")
+    async def test_optimize_speech(self, is_drone, get_webhook_for_channel, send_webhook_with_specific_output, is_optimized):
         # setup
         message = AsyncMock()
         message.content = "3287 :: 122"
@@ -81,6 +90,7 @@ class SpeechOptimizationTest(unittest.IsolatedAsyncioTestCase):
         message.author.roles = [drone_role, optimized_role]
 
         is_optimized.return_value = True
+        is_drone.return_value = True
 
         webhook = AsyncMock()
         get_webhook_for_channel.return_value = webhook

--- a/test/test_speech_optimization.py
+++ b/test/test_speech_optimization.py
@@ -53,11 +53,15 @@ class SpeechOptimizationTest(unittest.IsolatedAsyncioTestCase):
         message.delete.assert_not_called()
         self.assertFalse(response)
 
-    async def test_print_status_code_from_nondrone(self):
+    @patch("ai.speech_optimization.is_optimized")
+    async def test_print_status_code_from_nondrone(self, is_optimized):
         # setup
         message = AsyncMock()
         message.content = "0000 :: 050"
+        message.author.display_name = "Sonata"
         message.author.roles = []
+
+        is_optimized.return_value = False
 
         # run
         response = await speech_optimization.optimize_speech(message)


### PR DESCRIPTION
For some reason, we weren't doing any checks if the author of a message that was being processed for status codes had the drone role or not. That's been fixed now.

Fixes #190.