### PR TITLE
pinned build image to ubuntu-20.04

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       # get latest code
       - uses: actions/checkout@v2


### PR DESCRIPTION
This is a good practice, because with `latest` the version actually used could shift without us really noticing and suddenly our CI stops working. Using `latest` is okay when prototyping, but it should be changed to versions when systems become established.

I chose ubuntu-20.04 because ubuntu-latest will change to that version in a few weeks as well and it works for our project.

see https://github.com/actions/virtual-environments/issues/1816 for more information as well