### PR TITLE
Feature/199 images in reposted messages

### DIFF
--- a/ai/data_objects.py
+++ b/ai/data_objects.py
@@ -3,8 +3,10 @@ class MessageCopy:
         self,
         content=None,
         display_name=None,
-        avatar_url=None
+        avatar_url=None,
+        attachments=None
     ):
         self.content = content
         self.display_name = display_name
         self.avatar_url = avatar_url
+        self.attachments = attachments

--- a/ai/data_objects.py
+++ b/ai/data_objects.py
@@ -4,7 +4,7 @@ class MessageCopy:
         content=None,
         display_name=None,
         avatar_url=None,
-        attachments=None
+        attachments=[]
     ):
         self.content = content
         self.display_name = display_name

--- a/ai/speech_optimization.py
+++ b/ai/speech_optimization.py
@@ -141,7 +141,7 @@ async def optimize_speech(message: discord.Message, message_copy):
 
     # Strip attachments only if a drone is optimized via hc!tso.
     if is_optimized(message.author):
-        message_copy.attachments = None
+        message_copy.attachments = []
 
     # If the message is written by a drone with speech optimization, and the message is NOT a valid message, delete it.
 

--- a/ai/speech_optimization.py
+++ b/ai/speech_optimization.py
@@ -138,6 +138,11 @@ async def print_status_code(message: discord.Message):
 
 
 async def optimize_speech(message: discord.Message, message_copy):
+
+    # Strip attachments only if a drone is optimized via hc!tso.
+    if is_optimized(message.author):
+        message_copy.attachments = None
+
     # If the message is written by a drone with speech optimization, and the message is NOT a valid message, delete it.
 
     acceptable_status_code_message = plain_status_code_regex.match(message.content)

--- a/main.py
+++ b/main.py
@@ -383,7 +383,7 @@ async def on_message(message: discord.Message):
         await bot.process_commands(message)
         return
 
-    message_copy = MessageCopy(message.content, message.author.display_name, message.author.avatar_url)
+    message_copy = MessageCopy(message.content, message.author.display_name, message.author.avatar_url, message.attachments)
 
     LOGGER.info("Beginning message listener stack execution.")
     for listener in message_listeners:

--- a/test/test_webhook.py
+++ b/test/test_webhook.py
@@ -107,7 +107,7 @@ class TestWebhook(unittest.IsolatedAsyncioTestCase):
         The webhook_if_message altered function should read each Attachment object in the MessageCopy's attachments attribute
         and convert them into appropriate discord.File objects before passing them to the proxy_message_by_webhook function.
 
-        This is because discord.Message objects have a list of discord.Attachments to represent files, 
+        This is because discord.Message objects have a list of discord.Attachments to represent files,
         but webhooks require discord.File objects.
         '''
 
@@ -139,6 +139,6 @@ class TestWebhook(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(converted_file_one.filename, expected_file_one.filename)
         self.assertEqual(converted_file_two.filename, expected_file_two.filename)
-        
+
         self.assertEqual(converted_file_one.fp.read(), expected_file_one.fp.read())
         self.assertEqual(converted_file_two.fp.read(), expected_file_two.fp.read())

--- a/test/test_webhook.py
+++ b/test/test_webhook.py
@@ -45,6 +45,7 @@ class TestWebhook(unittest.IsolatedAsyncioTestCase):
         send_webhook.assert_called_once_with(message_content=message_copy.content,
                                              message_username=message_copy.display_name,
                                              message_avatar=message_copy.avatar_url,
+                                             message_attachments=[],
                                              channel=message_original.channel,
                                              webhook=None)
 
@@ -69,6 +70,7 @@ class TestWebhook(unittest.IsolatedAsyncioTestCase):
         send_webhook.assert_called_once_with(message_content=message_copy.content,
                                              message_username=message_copy.display_name,
                                              message_avatar=message_copy.avatar_url,
+                                             message_attachments=[],
                                              channel=message_original.channel,
                                              webhook=None)
 
@@ -93,5 +95,6 @@ class TestWebhook(unittest.IsolatedAsyncioTestCase):
         send_webhook.assert_called_once_with(message_content=message_copy.content,
                                              message_username=message_copy.display_name,
                                              message_avatar=message_copy.avatar_url,
+                                             message_attachments=[],
                                              channel=message_original.channel,
                                              webhook=None)

--- a/webhook.py
+++ b/webhook.py
@@ -1,11 +1,12 @@
 import discord
 import logging
 from ai.data_objects import MessageCopy
+import io
 
 LOGGER = logging.getLogger("ai")
 
 
-async def proxy_message_by_webhook(message_content, message_username=None, message_avatar=None, webhook=None, channel=None):
+async def proxy_message_by_webhook(message_content, message_username=None, message_avatar=None, message_attachments=None, webhook=None, channel=None):
     '''
     Proxies a message via webhook. If a webhook is not provided, one will be retrieved via the channel object passed as a parameter.
     If neither a webhook or channel object are passed, this function will do nothing.
@@ -19,7 +20,7 @@ async def proxy_message_by_webhook(message_content, message_username=None, messa
         LOGGER.warn(f"Failed to retrieve a webhook. Could not proxy message: '{message_content}'")
         return False
 
-    await webhook.send(message_content, avatar_url=message_avatar, username=message_username)
+    await webhook.send(message_content, avatar_url=message_avatar, username=message_username, files=message_attachments)
 
 
 async def get_webhook_for_channel(channel: discord.TextChannel) -> discord.Webhook:
@@ -40,9 +41,18 @@ async def webhook_if_message_altered(original: discord.Message, copy: MessageCop
     '''
     if original.content != copy.content or original.author.display_name != copy.display_name or original.author.avatar_url != copy.avatar_url:
         LOGGER.info("Proxying altered message.")
+
+        LOGGER.info("Converting all attachments")
+        # Convert available Attachment objects into File objects.
+        attachments_as_files = []
+        for attachment in copy.attachments:
+            attachments_as_files.append(discord.File(io.BytesIO(await attachment.read()), filename=attachment.filename))
+        LOGGER.info("Attachments converted.")
+
         await original.delete()
         await proxy_message_by_webhook(message_content=copy.content,
                                        message_username=copy.display_name,
                                        message_avatar=copy.avatar_url,
+                                       message_attachments=attachments_as_files,
                                        channel=original.channel,
                                        webhook=None)


### PR DESCRIPTION
Fixes #199 

- MessageCopy now has an attachments attribute, which is an empty array by default.
- Speech optimization module will set MessageCopy attachments to [] if user is optimized.
- Webhook module now converts each discord.Attachment object to a discord.File object which can be used by the webhook so that messages with images can be faithfully recreated by proxy.