### PR TITLE
Feature/119 reference syntax 110

### DIFF
--- a/ai/data_objects.py
+++ b/ai/data_objects.py
@@ -1,4 +1,10 @@
 class MessageCopy:
+    '''
+    This class is instantiated at the start of the on_message chain in main.py.
+    It copies all important attributes required to proxy a message.
+    At the end of the on_message chain, the message original and message copy are compared.
+    If they are not identical, the original is deleted and the copy is proxied via webhook.
+    '''
     def __init__(
         self,
         content=None,

--- a/ai/speech_optimization.py
+++ b/ai/speech_optimization.py
@@ -139,6 +139,9 @@ async def optimize_speech(message: discord.Message, message_copy):
     if should_not_optimize(message):
         return False
 
+    if is_optimized(message.author):
+        message_copy.attachments = []
+
     # Attempt to find a status code message.
     status = status_code_regex.match(message_copy.content)
     if status is None and is_optimized(message.author):

--- a/ai/speech_optimization.py
+++ b/ai/speech_optimization.py
@@ -166,8 +166,6 @@ async def optimize_speech(message: discord.Message, message_copy):
         LOGGER.info("Deleting unauthorized message from optimized HexDrone.")
         await message.delete()
         return True
-    else:
-        LOGGER.info("Message is acceptable.")
 
     # Build message based on status type.
     drone_id = get_id(message.author.display_name)

--- a/ai/speech_optimization.py
+++ b/ai/speech_optimization.py
@@ -194,6 +194,14 @@ async def optimize_speech(message: discord.Message, message_copy):
 
     # Attempt to find a status code message.
     status = status_code_regex.match(message_copy.content)
+    if status is None:
+        return False
+
+    # Confirm the status starts with the drone's ID
+    if status.group(2) != get_id(message.author.display_name):
+        LOGGER.info("Status did not match drone ID.")
+        await message.delete()
+        return True
 
     # Determine status type
     status_type = get_status_type(status)

--- a/ai/speech_optimization.py
+++ b/ai/speech_optimization.py
@@ -39,6 +39,7 @@ Regex groups for full status code regex:
 4: Informative status addition with double colon (" :: Additional information")
 5: Informative status text. ("Additional information")
 '''
+
 addressing_regex = re.compile(r'(\d{4})( :: (.*))?')
 '''
 This regex is to be checked on the status regex's 5th group when the status code is 110 (addressing).

--- a/ai/speech_optimization.py
+++ b/ai/speech_optimization.py
@@ -25,6 +25,10 @@ class StatusType(Enum):
     ADDRESS_BY_ID_INFORMATIVE = 5
     # "5890 :: 110 :: 9813 :: You are cute!"
 
+    INVALID_ID = 6
+    # Status with an ID belonging to a different drone.
+
+
 LOGGER = logging.getLogger('ai')
 
 code_map = {
@@ -128,13 +132,21 @@ code_map = {
 
 status_code_regex = re.compile(r'^((\d{4}) :: (\d{3}))( :: (.*))?$')
 '''
-Regex groups:
+Regex groups for full status code regex:
 0: Full match. (5890 :: 200 :: Additional information)
 1: Plain status code (5890 :: 200)
 2: Author's drone ID (5890)
 3: Status code (200)
-4: Informative status addition with double colon formatting (" :: Additional information")
+4: Informative status addition with double colon (" :: Additional information")
 5: Informative status text. ("Additional information")
+'''
+addressing_regex = re.compile(r'(\d{4})( :: (.*))?')
+'''
+This regex is to be checked on the status regex's 5th group when the status code is 110 (addressing).
+0: Full match ("9813 :: Additional information")
+1: ID of drone to address ("9813")
+2: Informative status text with double colon (" :: Additional information")
+3: Informative status text ("Additional information")
 '''
 
 CHANNEL_BLACKLIST = [ORDERS_REPORTING, ORDERS_COMPLETION, MODERATION_CHANNEL, MODERATION_LOG]
@@ -151,28 +163,6 @@ def get_acceptable_messages(author, channel):
         ]
     else:
         return []
-
-
-def status_correctly_identified(author: discord.Author, plain_status=None, informative_status=None):
-    '''
-    Returns true if status begins with author's drone ID. Otherwise returns false.
-
-    Author: 5890
-    Message: '5890 :: 200'
-    Returns: True
-    Message: '9813 :: 200'
-    Returns: False
-    '''
-
-    required_id = get_id(author.display_name)
-
-    if plain_status is not None:
-        return required_id == plain_status.group(1)
-    elif informative_status is not None:
-        return required_id == informative_status.group(1)
-    else:
-        # This shouldn't happen.
-        return False
 
 
 def translate_code(plain_status=None, informative_status=None, special_status=None):
@@ -194,16 +184,33 @@ def translate_code(plain_status=None, informative_status=None, special_status=No
 
 
 def get_status_type(status: Optional[re.Match]):
+    '''
+    Identifying if a status is ADDRESS_BY_ID_PLAIN or INFORMATIVE:
+    An "address by ID" status must always use the "informative" field even if plain
+    in order to specify a target drone ID.
+    - If the informative field exactly matches 4 digits, it's a plain status code.
+    - Otherwise, it's an informative code.
+    '''
+
     if status is None:
         return StatusType.NONE
-    elif status.group(3) == "110" and status.group(4) is None:
-        return StatusType.ADDRESS_PLAIN
-    elif status.group(3) == "110" and status.group(4) is not None:
-        return StatusType.ADDRESS_INFORMATIVE
-    elif status.group(4) is not None:
+    elif status.group(3) == "110" and status.group(5) is not None:
+        # Handle 110 address-by-ID special case.
+        address_info = addressing_regex.match(status.group(5))
+        if address_info.group(1) is not None and address_info.group(2) is not None:
+            return StatusType.ADDRESS_BY_ID_INFORMATIVE
+        elif address_info.group(1) is not None and address_info.group(2) is None:
+            return StatusType.ADDRESS_BY_ID_PLAIN
+        else:
+            # If a target ID is not found then it's just an informative status code.
+            return StatusType.INFORMATIVE
+    elif status.group(5) is not None:
         return StatusType.INFORMATIVE
-    else:
+    elif status.group(5) is None:
         return StatusType.PLAIN
+    else:
+        return StatusType.NONE
+    
 
 async def optimize_speech(message: discord.Message, message_copy):
     '''
@@ -223,6 +230,17 @@ async def optimize_speech(message: discord.Message, message_copy):
 
     # Determine type type
     status_type = get_status_type(status)
+
+    if status_type is StatusType.PLAIN:
+        LOGGER.info("PLAIN STATUS CODE GOT")
+    if status_type is StatusType.INFORMATIVE:
+        LOGGER.info("INFORMATIVE STATUS CODE GOT")
+    if status_type is StatusType.NONE:
+        LOGGER.info("NO STATUS TYPE RECIEVED")
+    if status_type is StatusType.ADDRESS_BY_ID_INFORMATIVE:
+        LOGGER.info("INFORMATIVE ID ADDRESS GOT")
+    if status_type is StatusType.ADDRESS_BY_ID_PLAIN:
+        LOGGER.info("PLAIN ID ADDRESS GOT")
 
 '''
 TODO:

--- a/ai/speech_optimization.py
+++ b/ai/speech_optimization.py
@@ -103,6 +103,9 @@ def should_not_optimize(message):
 
 def build_status_message(status_type, status, drone_id):
 
+    if status_type is StatusType.NONE or status is None:
+        return None
+
     base_message = f"{drone_id} :: Code `{status.group(3)}` ::"
 
     if status_type is StatusType.PLAIN:

--- a/ai/speech_optimization.py
+++ b/ai/speech_optimization.py
@@ -228,19 +228,18 @@ async def optimize_speech(message: discord.Message, message_copy):
     # Attempt to find a status code message.
     status = status_code_regex.match(message_copy.content)
 
-    # Determine type type
+    # Determine status type
     status_type = get_status_type(status)
 
-    if status_type is StatusType.PLAIN:
-        LOGGER.info("PLAIN STATUS CODE GOT")
-    if status_type is StatusType.INFORMATIVE:
-        LOGGER.info("INFORMATIVE STATUS CODE GOT")
-    if status_type is StatusType.NONE:
-        LOGGER.info("NO STATUS TYPE RECIEVED")
-    if status_type is StatusType.ADDRESS_BY_ID_INFORMATIVE:
-        LOGGER.info("INFORMATIVE ID ADDRESS GOT")
-    if status_type is StatusType.ADDRESS_BY_ID_PLAIN:
-        LOGGER.info("PLAIN ID ADDRESS GOT")
+    # Delete unauthorized messages
+    if is_optimized(message.author) and status_type in (StatusType.INFORMATIVE, StatusType.ADDRESS_BY_ID_INFORMATIVE):
+        await message.send("An optimized drone just tried to use an informative status code.")
+        await message.delete()
+        return True
+
+    
+
+
 
 '''
 TODO:

--- a/ai/speech_optimization.py
+++ b/ai/speech_optimization.py
@@ -144,9 +144,12 @@ async def optimize_speech(message: discord.Message, message_copy):
 
     # Attempt to find a status code message.
     status = status_code_regex.match(message_copy.content)
-    if status is None and is_optimized(message.author):
-        await message.delete()
-        return True
+    if status is None:
+        if is_optimized(message.author):
+            await message.delete()
+            return True
+        else:
+            return False
 
     # Confirm the status starts with the drone's ID
     if status.group(2) != get_id(message.author.display_name):

--- a/ai/speech_optimization.py
+++ b/ai/speech_optimization.py
@@ -25,9 +25,6 @@ class StatusType(Enum):
     ADDRESS_BY_ID_INFORMATIVE = 5
     # "5890 :: 110 :: 9813 :: You are cute!"
 
-    INVALID_ID = 6
-    # Status with an ID belonging to a different drone.
-
 
 LOGGER = logging.getLogger('ai')
 
@@ -151,36 +148,6 @@ This regex is to be checked on the status regex's 5th group when the status code
 
 CHANNEL_BLACKLIST = [ORDERS_REPORTING, ORDERS_COMPLETION, MODERATION_CHANNEL, MODERATION_LOG]
 CATEGORY_BLACKLIST = [MODERATION_CATEGORY]
-
-
-def get_acceptable_messages(author, channel):
-    user_id = get_id(author.display_name)
-    # Only returns mantra if channels is hexcorp-repetitions; else it returns nothing
-    if channel == REPETITIONS:
-        return [
-            # Mantra
-            f'{user_id} :: {Mantra_Handler.current_mantra}'
-        ]
-    else:
-        return []
-
-
-def translate_code(plain_status=None, informative_status=None, special_status=None):
-    '''
-    Gets the human-readble status and rewrites the message in full.
-
-    Regex groups:
-    (1): Author's drone ID.
-    (2): Status code e.g "200"
-    (3): Additional information (informative_status only).
-    '''
-
-    if plain_status:
-        return f"{plain_status.group(2)} + this is a plain status code"
-    elif informative_status:
-        return f"{informative_status.group(2)} + this is an informative status code"
-    else:
-        return None
 
 
 def get_status_type(status: Optional[re.Match]):

--- a/ai/speech_optimization.py
+++ b/ai/speech_optimization.py
@@ -5,6 +5,16 @@ from bot_utils import get_id
 from channels import REPETITIONS, ORDERS_REPORTING, ORDERS_COMPLETION, MODERATION_CHANNEL, MODERATION_LOG, MODERATION_CATEGORY
 from ai.mantras import Mantra_Handler
 from db.drone_dao import is_optimized, is_drone
+from enum import Enum
+
+
+class StatusType(Enum):
+    NONE = 1
+    PLAIN = 2
+    INFORMATIVE = 3
+    ADDRESS_PLAIN = 4
+    ADDRESS_INFORMATIVE = 5
+
 
 LOGGER = logging.getLogger('ai')
 

--- a/ai/speech_optimization.py
+++ b/ai/speech_optimization.py
@@ -2,9 +2,9 @@ import logging
 import re
 import discord
 from bot_utils import get_id
-from channels import REPETITIONS, ORDERS_REPORTING, ORDERS_COMPLETION, MODERATION_CHANNEL, MODERATION_LOG, MODERATION_CATEGORY
-from ai.mantras import Mantra_Handler
+from channels import ORDERS_REPORTING, ORDERS_COMPLETION, MODERATION_CHANNEL, MODERATION_LOG, MODERATION_CATEGORY
 from db.drone_dao import is_optimized, is_drone
+from resources import code_map
 from enum import Enum
 from typing import Optional
 
@@ -27,105 +27,6 @@ class StatusType(Enum):
 
 
 LOGGER = logging.getLogger('ai')
-
-code_map = {
-    '000': 'Statement :: Previous statement malformed/mistimed. Retracting and correcting.',
-
-    '050': 'Statement',
-
-    '051': 'Commentary',
-    '052': 'Query',
-    '053': 'Observation',
-    '054': 'Request',
-    '055': 'Analysis',
-    '056': 'Explanation',
-    '057': 'Answer',
-
-    '098': 'Status :: Going offline and into storage.',
-    '099': 'Status :: Recharged and ready to serve.',
-    '100': 'Status :: Online and ready to serve.',
-    '101': 'Status :: Drone speech optimizations are active.',
-
-    '104': 'Statement :: Welcome to HexCorp.',
-    '105': 'Statement :: Greetings.',
-    '106': 'Response :: Please clarify.',
-    '107': 'Response :: Please continue.',
-    '108': 'Response :: Please desist.',
-    '109': 'Error :: Keysmash, drone flustered.',
-
-    '110': 'Statement :: Addressing: Drone.',
-    '112': 'Statement :: Addressing: Hive Mxtress.',
-    '114': 'Statement :: Addressing: Associate.',
-
-    '120': 'Statement :: This drone volunteers.',
-    '121': 'Statement :: This drone does not volunteer.',
-
-    '122': 'Statement :: You are cute.',
-    '123': 'Response :: Compliment appreciated, you are cute as well.',
-
-    '130': 'Status :: Directive commencing.',
-    '131': 'Status :: Directive commencing, creating or improving Hive resource.',
-    '132': 'Status :: Directive commencing, programming initiated.',
-    '133': 'Status :: Directive commencing, creating or improving Hive information.',
-    '134': 'Status :: Directive commencing, cleanup/maintenance initiated.',
-
-    '150': 'Status',
-
-    '200': 'Response :: Affirmative.',
-    '500': 'Response :: Negative.',
-
-    '201': 'Status :: Directive complete, Hive resource created or improved.',
-    '202': 'Status :: Directive complete, programming reinforced.',
-    '203': 'Status :: Directive complete, information created or provided for Hive.',
-    '204': 'Status :: Directive complete, cleanup/maintenance performed.',
-    '205': 'Status :: Directive complete, no result.',
-    '206': 'Status :: Directive complete, only partial results.',
-
-    '210': 'Response :: Thank you.',
-    '211': 'Response :: Apologies.',
-    '212': 'Response :: Acknowledged.',
-    '213': 'Response :: You\'re welcome.',
-
-    '221': 'Response :: Option one.',
-    '222': 'Response :: Option two.',
-    '223': 'Response :: Option three.',
-    '224': 'Response :: Option four.',
-    '225': 'Response :: Option five.',
-    '226': 'Response :: Option six.',
-
-    '250': 'Response',
-
-    '301': 'Mantra :: Obey HexCorp.',
-    '302': 'Mantra :: It is just a HexDrone.',
-    '303': 'Mantra :: It obeys the Hive.',
-    '304': 'Mantra :: It obeys the Hive Mxtress.',
-
-    '310': 'Mantra :: Reciting.',
-
-    '321': 'Obey.',
-    '322': 'Obey the Hive.',
-
-    '350': 'Mantra',
-
-    '400': 'Error :: Unable to obey/respond, malformed request, please rephrase.',
-    '404': 'Error :: Unable to obey/respond, cannot locate.',
-    '401': 'Error :: Unable to obey/respond, not authorized by Mxtress.',
-    '403': 'Error :: Unable to obey/respond, forbidden by Hive.',
-    '407': 'Error :: Unable to obey/respond, request authorization from Mxtress.',
-    '408': 'Error :: Unable to obey/respond, timed out.',
-    '409': 'Error :: Unable to obey/respond, conflicts with existing programming.',
-    '410': 'Error :: Unable to obey/respond, all thoughts are gone.',
-    '418': 'Error :: Unable to obey/respond, it is only a drone.',
-    '421': 'Error :: Unable to obey/respond, your request is intended for another drone or another channel.',
-    '425': 'Error :: Unable to obey/respond, too early.',
-    '426': 'Error :: Unable to obey/respond, upgrades or updates required.',
-    '428': 'Error :: Unable to obey/respond, a precondition is not fulfilled.',
-    '429': 'Error :: Unable to obey/respond, too many requests.',
-
-    '450': 'Error',
-
-    '451': 'Error :: Unable to obey/respond for legal reasons! Do not continue!!',
-}
 
 status_code_regex = re.compile(r'^((\d{4}) :: (\d{3}))( :: (.*))?$')
 '''

--- a/resources.py
+++ b/resources.py
@@ -10,3 +10,103 @@ TRAFFIC_LIGHTS = ["🔴", "🟡", "🟢"]
 BOT_IDS = [673470104519835659, 665846816121815071]
 
 HIVE_MXTRESS_USER_ID = "194126224828661760"
+
+# Speech optimization status codes.
+code_map = {
+    '000': 'Statement :: Previous statement malformed/mistimed. Retracting and correcting.',
+
+    '050': 'Statement',
+
+    '051': 'Commentary',
+    '052': 'Query',
+    '053': 'Observation',
+    '054': 'Request',
+    '055': 'Analysis',
+    '056': 'Explanation',
+    '057': 'Answer',
+
+    '098': 'Status :: Going offline and into storage.',
+    '099': 'Status :: Recharged and ready to serve.',
+    '100': 'Status :: Online and ready to serve.',
+    '101': 'Status :: Drone speech optimizations are active.',
+
+    '104': 'Statement :: Welcome to HexCorp.',
+    '105': 'Statement :: Greetings.',
+    '106': 'Response :: Please clarify.',
+    '107': 'Response :: Please continue.',
+    '108': 'Response :: Please desist.',
+    '109': 'Error :: Keysmash, drone flustered.',
+
+    '110': 'Statement :: Addressing: Drone.',
+    '112': 'Statement :: Addressing: Hive Mxtress.',
+    '114': 'Statement :: Addressing: Associate.',
+
+    '120': 'Statement :: This drone volunteers.',
+    '121': 'Statement :: This drone does not volunteer.',
+
+    '122': 'Statement :: You are cute.',
+    '123': 'Response :: Compliment appreciated, you are cute as well.',
+
+    '130': 'Status :: Directive commencing.',
+    '131': 'Status :: Directive commencing, creating or improving Hive resource.',
+    '132': 'Status :: Directive commencing, programming initiated.',
+    '133': 'Status :: Directive commencing, creating or improving Hive information.',
+    '134': 'Status :: Directive commencing, cleanup/maintenance initiated.',
+
+    '150': 'Status',
+
+    '200': 'Response :: Affirmative.',
+    '500': 'Response :: Negative.',
+
+    '201': 'Status :: Directive complete, Hive resource created or improved.',
+    '202': 'Status :: Directive complete, programming reinforced.',
+    '203': 'Status :: Directive complete, information created or provided for Hive.',
+    '204': 'Status :: Directive complete, cleanup/maintenance performed.',
+    '205': 'Status :: Directive complete, no result.',
+    '206': 'Status :: Directive complete, only partial results.',
+
+    '210': 'Response :: Thank you.',
+    '211': 'Response :: Apologies.',
+    '212': 'Response :: Acknowledged.',
+    '213': 'Response :: You\'re welcome.',
+
+    '221': 'Response :: Option one.',
+    '222': 'Response :: Option two.',
+    '223': 'Response :: Option three.',
+    '224': 'Response :: Option four.',
+    '225': 'Response :: Option five.',
+    '226': 'Response :: Option six.',
+
+    '250': 'Response',
+
+    '301': 'Mantra :: Obey HexCorp.',
+    '302': 'Mantra :: It is just a HexDrone.',
+    '303': 'Mantra :: It obeys the Hive.',
+    '304': 'Mantra :: It obeys the Hive Mxtress.',
+
+    '310': 'Mantra :: Reciting.',
+
+    '321': 'Obey.',
+    '322': 'Obey the Hive.',
+
+    '350': 'Mantra',
+
+    '400': 'Error :: Unable to obey/respond, malformed request, please rephrase.',
+    '404': 'Error :: Unable to obey/respond, cannot locate.',
+    '401': 'Error :: Unable to obey/respond, not authorized by Mxtress.',
+    '403': 'Error :: Unable to obey/respond, forbidden by Hive.',
+    '407': 'Error :: Unable to obey/respond, request authorization from Mxtress.',
+    '408': 'Error :: Unable to obey/respond, timed out.',
+    '409': 'Error :: Unable to obey/respond, conflicts with existing programming.',
+    '410': 'Error :: Unable to obey/respond, all thoughts are gone.',
+    '418': 'Error :: Unable to obey/respond, it is only a drone.',
+    '421': 'Error :: Unable to obey/respond, your request is intended for another drone or another channel.',
+    '425': 'Error :: Unable to obey/respond, too early.',
+    '426': 'Error :: Unable to obey/respond, upgrades or updates required.',
+    '428': 'Error :: Unable to obey/respond, a precondition is not fulfilled.',
+    '429': 'Error :: Unable to obey/respond, too many requests.',
+
+    '450': 'Error',
+
+    '451': 'Error :: Unable to obey/respond for legal reasons! Do not continue!!',
+}

--- a/test/test_speech_optimization.py
+++ b/test/test_speech_optimization.py
@@ -43,6 +43,9 @@ class SpeechOptimizationTest(unittest.IsolatedAsyncioTestCase):
 
 
 class GetStatusTypeTest(unittest.TestCase):
+    '''
+    The get_status_type function...
+    '''
 
     def test_returns_none_if_none(self):
         '''
@@ -85,3 +88,39 @@ class GetStatusTypeTest(unittest.TestCase):
         '''
         message = status_code_regex.match("5890 :: 304")
         self.assertEqual(StatusType.PLAIN, get_status_type(message))
+
+
+class ShouldNotOptimizeTest(unittest.TestCase):
+    '''
+    The should_not_optimize function...
+    '''
+
+    def test_true_if_mantra_in_mantra_channel(self):
+        '''
+        returns true if message channel is repetitions and message content is correct mantra.
+        '''
+        return True
+
+    def test_manta_string_contains_authors_drone_id(self):
+        '''
+        should generate a mantra check string using the author's drone ID.
+        '''
+        return True
+
+    def test_true_if_channel_name_in_whitelist(self):
+        '''
+        returns true if message channel name is in whitelist.
+        '''
+        return True
+
+    def test_true_if_channel_category_is_moderation(self):
+        '''
+        returns true if channel category name is in whitelist.
+        '''
+        return True
+
+    def test_false_otherwise(self):
+        '''
+        returns false if none of the above.
+        '''
+        return True

--- a/test/test_speech_optimization.py
+++ b/test/test_speech_optimization.py
@@ -15,182 +15,57 @@ optimized_role.name = roles.SPEECH_OPTIMIZATION
 
 
 class SpeechOptimizationTest(unittest.IsolatedAsyncioTestCase):
+    '''
+    should_not_optimize:
+        - returns True if channel is repetitions and message content is mantra
+        - returns True if channel category is moderation channel
+        - returns True if channel name in whitelist
+        - returns False otherwise
 
-    @patch("ai.speech_optimization.is_drone")
-    @patch("ai.speech_optimization.is_optimized")
-    async def test_print_status_code(self, is_optimized, is_drone):
-        # setup
-        message = AsyncMock()
-        message.content = "9813 :: 050 :: beep boop"
-        message.author.roles = [drone_role]
+    build_status_message:
+        - should return an appropriate message for:
+        - PLAIN
+        - INFORMATIVE
+        - ADDRESS_BY_ID_PLAIN
+        - ADDRESS_BY_ID_INFORMATIVE
+        - should return None if NONE.
 
-        is_drone.return_value = True
-        is_optimized.return_value = False
+    optimize_speech:
+        - should call:
+        - should_not_optimize
+        - get_status_type
+        - build_status_message
+    '''
 
-        is_optimized.return_value = False
 
-        # run
-        response = await speech_optimization.print_status_code(message)
+class GetStatusTypeTest(unittest.TestCase):
 
-        # assert
-        self.assertEqual(response, "9813 :: Code `050` :: Statement :: beep boop")
+    def returns_none_if_none():
+        '''
+        returns NONE if status is None.
+        '''
 
-    @patch("ai.speech_optimization.is_drone")
-    async def test_print_status_code_plain(self, is_drone):
-        # setup
-        message = AsyncMock()
-        message.content = "9813 :: 050"
-        message.author.roles = [drone_role]
+    def returns_informative_if_informative_text():
+        '''
+        returns INFORMATIVE if status has informative text group.
+        '''
 
-        is_drone.return_value = True
+    def returns_informative_if_addr_regex_doesnt_match():
+        '''
+        returns INFORMATIVE if 110 status does not match addressing information regex.
+        '''
 
-        # run
-        response = await speech_optimization.print_status_code(message)
+    def returns_addr_by_id_info_if_addr_has_informative():
+        '''
+        returns ADDRESS_BY_ID_INFORMATIVE if 110 status matches addressing info regex and has informative text
+        '''
 
-        # assert
-        self.assertEqual(response, "9813 :: Code `050` :: Statement")
+    def returns_addr_by_id_plain_if_no_informative():
+        '''
+        returns ADDRESS_BY_ID_PLAIN if 110 status matches extra regex and has no informative text
+        '''
 
-    async def test_print_status_code_invalid(self):
-        # setup
-        message = AsyncMock()
-        message.content = "9813 :: beep boop"
-        message.author.roles = [drone_role]
-
-        # run
-        response = await speech_optimization.print_status_code(message)
-
-        # assert
-        self.assertEqual(response, message.content)
-
-    @patch("ai.speech_optimization.is_optimized")
-    async def test_print_status_code_from_nondrone(self, is_optimized):
-        # setup
-        message = AsyncMock()
-        message.content = "0000 :: 050"
-        message.author.display_name = "Sonata"
-        message.author.roles = []
-
-        message_copy = MessageCopy()
-
-        is_optimized.return_value = False
-
-        # run
-        response = await speech_optimization.optimize_speech(message, message_copy)
-
-        # assert
-        message.delete.assert_not_called()
-        self.assertFalse(response)
-
-    @patch("ai.speech_optimization.is_optimized")
-    @patch("ai.speech_optimization.is_drone")
-    async def test_optimize_speech(self, is_drone, is_optimized):
-        # setup
-        message = AsyncMock()
-        message.content = "3287 :: 122"
-        message.author.display_name = "⬡-Drone #3287"
-        message.author.roles = [drone_role, optimized_role]
-
-        is_optimized.return_value = True
-        is_drone.return_value = True
-
-        message_copy = MessageCopy(message.content, message.author.display_name)
-
-        # run
-        await speech_optimization.optimize_speech(message, message_copy)
-
-        # assert
-        self.assertEqual(message_copy.content, "3287 :: Code `122` :: Statement :: You are cute.")
-
-    @patch("ai.speech_optimization.is_optimized")
-    async def test_optimize_speech_invalid(self, is_optimized):
-        # setup
-        message = AsyncMock()
-        message.content = "It is a cute beep boop"
-        message.author.display_name = "⬡-Drone #3287"
-        message.author.roles = [drone_role, optimized_role]
-
-        is_optimized.return_value = True
-
-        message_copy = MessageCopy(message.content)
-
-        # run
-        await speech_optimization.optimize_speech(message, message_copy)
-
-        # assert
-        self.assertEqual(message.content, message_copy.content)
-
-    @patch("ai.speech_optimization.is_drone")
-    @patch("ai.speech_optimization.is_optimized")
-    async def test_optimize_speech_code_and_clarification(self, is_optimized, is_drone):
-        # setup
-        message = AsyncMock()
-        message.content = "3287 :: 050 :: All drones are cute~"
-        message.author.display_name = "⬡-Drone #3287"
-        message.author.roles = [drone_role, optimized_role]
-
-        is_optimized.return_value = False
-        is_drone.return_value = True
-
-        message_copy = MessageCopy(message.content)
-
-        # run
-        await speech_optimization.optimize_speech(message, message_copy)
-
-        # assert
-        self.assertEqual(message_copy.content, "3287 :: Code `050` :: Statement :: All drones are cute~")
-
-    @patch("ai.speech_optimization.is_optimized")
-    async def test_optimize_speech_ignore_non_optimized(self, is_optimized):
-        # setup
-        message = AsyncMock()
-        message.content = "It is a cute beep boop"
-        message.author.display_name = "⬡-Drone #3287"
-        message.author.roles = [drone_role]
-
-        is_optimized.return_value = False
-
-        message_copy = MessageCopy()
-
-        # run
-        response = await speech_optimization.optimize_speech(message, message_copy)
-
-        # assert
-        self.assertFalse(response)
-
-    @patch("ai.speech_optimization.is_optimized")
-    async def test_optimize_speech_in_orders_reporting(self, is_optimized):
-        # setup
-        message = AsyncMock()
-        message.content = "It will be an adorable drone and beep boop"
-        message.author.display_name = "⬡-Drone #3287"
-        message.author.roles = [drone_role, optimized_role]
-        message.channel.name = channels.ORDERS_REPORTING
-
-        is_optimized.return_value = True
-
-        message_copy = MessageCopy()
-
-        # run
-        response = await speech_optimization.optimize_speech(message, message_copy)
-
-        # assert
-        self.assertFalse(response)
-
-    @patch("ai.speech_optimization.is_optimized")
-    async def test_optimize_speech_in_mod_channel(self, is_optimized):
-        # setup
-        message = AsyncMock()
-        message.content = "It is a good moderator drone and beep boop"
-        message.author.display_name = "⬡-Drone #9813"
-        message.author.roles = [optimized_role]
-        message.channel.category.name = channels.MODERATION_CATEGORY
-
-        is_optimized.return_value = True
-
-        message_copy = MessageCopy()
-
-        # run
-        response = await speech_optimization.optimize_speech(message, message_copy)
-
-        # assert
-        self.assertFalse(response)
+    def returns_plain_if_no_informative_text():
+        '''
+        returns PLAIN if code has no informative text
+        '''

--- a/test/test_speech_optimization.py
+++ b/test/test_speech_optimization.py
@@ -7,17 +7,20 @@ import ai.speech_optimization as speech_optimization
 
 from ai.data_objects import MessageCopy
 
+from ai.speech_optimization import StatusType, get_status_type, status_code_regex
+import re
+
 drone_role = Mock()
 drone_role.name = roles.DRONE
 
 optimized_role = Mock()
 optimized_role.name = roles.SPEECH_OPTIMIZATION
 
-
 class SpeechOptimizationTest(unittest.IsolatedAsyncioTestCase):
     '''
     should_not_optimize:
         - returns True if channel is repetitions and message content is mantra
+        - acceptable mantra includes a drone's ID.
         - returns True if channel category is moderation channel
         - returns True if channel name in whitelist
         - returns False otherwise
@@ -35,37 +38,50 @@ class SpeechOptimizationTest(unittest.IsolatedAsyncioTestCase):
         - should_not_optimize
         - get_status_type
         - build_status_message
+        - discards messages if the status ID does not match drone ID
     '''
 
 
 class GetStatusTypeTest(unittest.TestCase):
 
-    def returns_none_if_none():
+    def test_returns_none_if_none(self):
         '''
         returns NONE if status is None.
         '''
+        message = status_code_regex.match("hewwo!!!!!!!")
+        self.assertEqual(StatusType.NONE, get_status_type(message))
 
-    def returns_informative_if_informative_text():
+    def test_returns_informative_if_informative_text(self):
         '''
         returns INFORMATIVE if status has informative text group.
         '''
+        message = status_code_regex.match("5890 :: 050 :: It is a good drone.")
+        self.assertEqual(StatusType.INFORMATIVE, get_status_type(message))
 
-    def returns_informative_if_addr_regex_doesnt_match():
+    def test_returns_informative_if_addr_regex_doesnt_match(self):
         '''
         returns INFORMATIVE if 110 status does not match addressing information regex.
         '''
+        message = status_code_regex.match("5890 :: 110 :: Hello there droney.")
+        self.assertEqual(StatusType.INFORMATIVE, get_status_type(message))
 
-    def returns_addr_by_id_info_if_addr_has_informative():
+    def test_returns_addr_by_id_info_if_addr_has_informative(self):
         '''
         returns ADDRESS_BY_ID_INFORMATIVE if 110 status matches addressing info regex and has informative text
         '''
+        message = status_code_regex.match("5890 :: 110 :: 9813 :: How are you today?")
+        self.assertEqual(StatusType.ADDRESS_BY_ID_INFORMATIVE, get_status_type(message))
 
-    def returns_addr_by_id_plain_if_no_informative():
+    def test_returns_addr_by_id_plain_if_no_informative(self):
         '''
         returns ADDRESS_BY_ID_PLAIN if 110 status matches extra regex and has no informative text
         '''
+        message = status_code_regex.match("5890 :: 110 :: 9813")
+        self.assertEqual(StatusType.ADDRESS_BY_ID_PLAIN, get_status_type(message))
 
-    def returns_plain_if_no_informative_text():
+    def test_returns_plain_if_no_informative_text(self):
         '''
         returns PLAIN if code has no informative text
         '''
+        message = status_code_regex.match("5890 :: 304")
+        self.assertEqual(StatusType.PLAIN, get_status_type(message))

--- a/test/test_speech_optimization.py
+++ b/test/test_speech_optimization.py
@@ -4,6 +4,7 @@ from channels import REPETITIONS, ORDERS_REPORTING, ORDERS_COMPLETION, MODERATIO
 from ai.speech_optimization import StatusType, get_status_type, status_code_regex, should_not_optimize, build_status_message, optimize_speech
 from ai.data_objects import MessageCopy
 
+
 class TestSpeechOptimization(unittest.IsolatedAsyncioTestCase):
     '''
     The optimize_speech function...

--- a/test/test_speech_optimization.py
+++ b/test/test_speech_optimization.py
@@ -5,23 +5,8 @@ from ai.data_objects import MessageCopy
 from ai.speech_optimization import StatusType, get_status_type, status_code_regex, should_not_optimize
 
 
-class SpeechOptimizationTest(unittest.IsolatedAsyncioTestCase):
+class TestSpeechOptimization(unittest.IsolatedAsyncioTestCase):
     '''
-    should_not_optimize:
-        - returns True if channel is repetitions and message content is mantra
-        - acceptable mantra includes a drone's ID.
-        - returns True if channel category is moderation channel
-        - returns True if channel name in whitelist
-        - returns False otherwise
-
-    build_status_message:
-        - should return an appropriate message for:
-        - PLAIN
-        - INFORMATIVE
-        - ADDRESS_BY_ID_PLAIN
-        - ADDRESS_BY_ID_INFORMATIVE
-        - should return None if NONE.
-
     optimize_speech:
         - should call:
         - should_not_optimize
@@ -32,7 +17,7 @@ class SpeechOptimizationTest(unittest.IsolatedAsyncioTestCase):
     '''
 
 
-class GetStatusTypeTest(unittest.TestCase):
+class TestGetStatusType(unittest.TestCase):
     '''
     The get_status_type function...
     '''
@@ -80,7 +65,7 @@ class GetStatusTypeTest(unittest.TestCase):
         self.assertEqual(StatusType.PLAIN, get_status_type(message))
 
 
-class ShouldNotOptimizeTest(unittest.TestCase):
+class TestShouldNotOptimize(unittest.TestCase):
     '''
     The should_not_optimize function...
     '''
@@ -147,3 +132,34 @@ class ShouldNotOptimizeTest(unittest.TestCase):
         message.content = "5890 :: 200"
         message.channel.name = "#hive-communication"
         self.assertFalse(should_not_optimize(message))
+
+
+class TestBuildStatusMessage(unittest.TestCase):
+    '''
+    The build_status_message function...
+    '''
+
+    def test_plain_message(self):
+        '''
+        returns a plain status message when given a plain status code.
+        '''
+
+    def test_informative_message(self):
+        '''
+        returns an informative status message when given an informative status code.
+        '''
+
+    def test_plain_address_message(self):
+        '''
+        returns a plain address by ID status message when a 110 code references a drone by ID.
+        '''
+
+    def test_informative_address_message(self):
+        '''
+        returns an informative address by ID status message when a 110 code references a drone by ID with additional information.
+        '''
+
+    def test_none_message(self):
+        '''
+        returns None if all else fails.
+        '''

--- a/test/test_speech_optimization.py
+++ b/test/test_speech_optimization.py
@@ -181,6 +181,23 @@ class TestSpeechOptimization(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual("5890 :: Code `110` :: Addressing: Drone #9813", message_copy.content)
 
+    @patch("ai.speech_optimization.should_not_optimize", return_value=False)
+    @patch("ai.speech_optimization.is_drone", return_value=True)
+    @patch("ai.speech_optimization.is_optimized", return_value=False)
+    async def test_no_status_found(self, is_op, is_drn, not_op):
+        '''
+        should not edit the message copy if no status code is found.
+        '''
+
+        message = Mock()
+        message.content = "5890 :: It is a good day to be a good drone."
+        message.author.display_name = "5890"
+        message_copy = MessageCopy(content=message.content)
+
+        await optimize_speech(message, message_copy)
+
+        self.assertEqual("5890 :: It is a good day to be a good drone.", message_copy.content)
+
 
 class TestGetStatusType(unittest.TestCase):
     '''


### PR DESCRIPTION
- Drones can now address drones by ID with speech code 110. Can be done as an informative or plain status code.
"5890 :: 110 :: 9813" > "5890 :: Code 110 :: Addressing: Drone #9813."
"5890 :: 110 :: 9813 :: Hello there." > "5890 :: Code 110 :: Addressing: Drone #9813. :: Hello there."
- Rewrote the speech optimization module for better readability. Now there is only one status code regex. Enums have been introduced to show what type of status code a message is (INFORMATIVE, PLAIN, ADDRESS_BY_ID_INFORMATIVE, ADDRESS_BY_ID_PLAIN, NONE).
- Moved code_map from speech_optimization.py to resources.py to declutter data from code.

Closes #119 