### PR TITLE
Feature/208 background tasks

### DIFF
--- a/ai/drone_configuration.py
+++ b/ai/drone_configuration.py
@@ -70,7 +70,7 @@ class DroneConfigurationCog(Cog):
                                get(context.guild.roles, name=ID_PREPENDING),
                                is_prepending_id,
                                lambda: "ID prepending is now mandatory.",
-                               lambda hours: f"ID prepending is now mandatory for {hours} hours.",
+                               lambda minutes: f"ID prepending is now mandatory for {minutes} minute(s).",
                                lambda: "Prepending? More like POST pending now that that's over! Haha!" if random.randint(1, 100) == 66 else "ID prependment policy relaxed.",
                                minutes)
 
@@ -86,7 +86,7 @@ class DroneConfigurationCog(Cog):
                                get(context.guild.roles, name=SPEECH_OPTIMIZATION),
                                is_optimized,
                                lambda: "Speech optimization is now active.",
-                               lambda hours: f"Speech optimization is now active for {hours} hours.",
+                               lambda minutes: f"Speech optimization is now active for {minutes} minute(s).",
                                lambda: "Speech optimization disengaged.",
                                minutes)
 
@@ -102,7 +102,7 @@ class DroneConfigurationCog(Cog):
                                get(context.guild.roles, name=IDENTITY_ENFORCEMENT),
                                is_identity_enforced,
                                lambda: "Identity enforcement is now active.",
-                               lambda hours: f"Identity enforcement is now active for {hours} hours.",
+                               lambda minutes: f"Identity enforcement is now active for {minutes} minute(s).",
                                lambda: "Identity enforcement disengaged.",
                                minutes)
 
@@ -118,7 +118,7 @@ class DroneConfigurationCog(Cog):
                                get(context.guild.roles, name=GLITCHED),
                                is_glitched,
                                lambda: "Uh.. it’s probably not a problem.. probably.. but I’m showing a small discrepancy in... well, no, it’s well within acceptable bounds again. Sustaining sequence." if random.randint(1, 100) == 66 else "Drone corruption at un̘͟s̴a̯f̺e͈͡ levels.",
-                               lambda hours: f"Drone corruption at un̘͟s̴a̯f̺e͈͡ levels for {hours} hours.",
+                               lambda minutes: f"Drone corruption scheduled to reflect un̘͟s̴a̯f̺e͈͡ levels for {minutes} minute(s).",
                                lambda: "Drone corruption at acceptable levels.",
                                minutes)
 

--- a/ai/status_message.py
+++ b/ai/status_message.py
@@ -23,7 +23,7 @@ class StatusMessageCog(Cog):
             Game("Drone Factory"),
             Game("Help, I'm trapped in a status message factory."),
             Game("hard to get with local hypnotists."),
-            Game("high-steaks games with my hypnodomme.")
+            Game("high-stakes games with my hypnodomme.")
         ]
 
     @tasks.loop(hours=48)

--- a/ai/status_message.py
+++ b/ai/status_message.py
@@ -1,30 +1,33 @@
 import random
-import asyncio
 import logging
-
-from discord.ext.commands import Bot
+from discord.ext.commands import Bot, Cog
+from discord.ext import tasks
 from discord import Game
 
-# as of November 2020 only Games are supported as status for bots: https://github.com/Rapptz/discord.py/issues/2400
-ACTIVITIES = [
-    Game("in the conversion chamber"),
-    Game("with your mind")
-]
 
-LOGGER = logging.getLogger('ai')
+class StatusMessageCog(Cog):
 
-# status is changed every two days for now
-STATUS_CHANGE_INTERVAL = 172800
+    def __init__(self, bot: Bot):
+        self.bot = bot
+        # discord.py only supports Game activites as of Nov 2020.
+        self.ACTIVITIES = [
+            Game("with your mind."),
+            Game("Beep boop."),
+            Game("with electric sheep."),
+            Game("in the conversion chamber."),
+            Game("with good drones."),
+            Game("HexCom 2.")
+        ]
+        self.LOGGER = logging.getLogger('ai')
+        print(bot)
+        # self.change_status.start()  # Begin loop.
 
+    @tasks.loop(hours=48)
+    async def change_status(self):
+        self.LOGGER.info("Changing status.")
+        await self.bot.change_presence(activity=random.choice(self.ACTIVITIES))
 
-async def start_change_status(bot: Bot):
-    LOGGER.info("Beginning routine change of status message.")
-    while True:
-        # Check active orders every minute.
-        LOGGER.debug("Changing status")
-        await change_status(bot)
-        await asyncio.sleep(STATUS_CHANGE_INTERVAL)
-
-
-async def change_status(bot: Bot):
-    await bot.change_presence(activity=random.choice(ACTIVITIES))
+    @change_status.before_loop
+    async def initialize_status(self):
+        self.LOGGER.info("Initial status setup.")
+        await self.bot.change_presence(activity=Game("All systems fully operational. Welcome to HexCorp."))

--- a/ai/status_message.py
+++ b/ai/status_message.py
@@ -9,6 +9,7 @@ class StatusMessageCog(Cog):
 
     def __init__(self, bot: Bot):
         self.bot = bot
+        self.LOGGER = logging.getLogger('ai')
         # discord.py only supports Game activites as of Nov 2020.
         self.ACTIVITIES = [
             Game("with your mind."),
@@ -16,11 +17,14 @@ class StatusMessageCog(Cog):
             Game("with electric sheep."),
             Game("in the conversion chamber."),
             Game("with good drones."),
-            Game("HexCom 2.")
+            Game("HexCom 2."),
+            Game("Dronification Squared"),
+            Game("Drone Hive Simulator"),
+            Game("Drone Factory"),
+            Game("Help, I'm trapped in a status message factory."),
+            Game("hard to get with local hypnotists."),
+            Game("high-steaks games with my hypnodomme.")
         ]
-        self.LOGGER = logging.getLogger('ai')
-        print(bot)
-        # self.change_status.start()  # Begin loop.
 
     @tasks.loop(hours=48)
     async def change_status(self):

--- a/ai/storage.py
+++ b/ai/storage.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 import re
 from datetime import datetime, timedelta

--- a/main.py
+++ b/main.py
@@ -91,21 +91,22 @@ message_listeners = [
 # Need to create cogs as a seperate variable so they can be assigned and have their tasks started after bot has booted.
 status_message_cog = status_message.StatusMessageCog(bot)
 storage_cog = storage.StorageCog(bot)
+orders_reporting_cog = orders_reporting.OrderReportingCog(bot)
 
 # Cogs with tasks that rely on the bot being active.
 bot.add_cog(status_message_cog)
 bot.add_cog(storage_cog)
+bot.add_cog(orders_reporting_cog)
 
+# Cogs that do not use tasks.
 bot.add_cog(emote.EmoteCog())
 bot.add_cog(drone_configuration.DroneConfigurationCog())
 bot.add_cog(add_voice.AddVoiceCog(bot))
 bot.add_cog(trusted_user.TrustedUserCog())
 bot.add_cog(drone_os_status.DroneOsStatusCog())
-bot.add_cog(orders_reporting.OrderReportingCog())
 bot.add_cog(status.StatusCog(message_listeners))
 bot.add_cog(Mantra_Handler(bot))
 bot.add_cog(amplify.AmplificationCog())
-
 
 
 @bot.command(usage=f'{bot.command_prefix}help')
@@ -195,9 +196,9 @@ async def on_ready():
         LOGGER.info("Starting up change_status loop.")
         status_message_cog.change_status.start()
 
-    if not checking_for_completed_orders:
-        asyncio.ensure_future(orders_reporting.start_check_for_completed_orders(bot))
-        checking_for_completed_orders = True
+    if not orders_reporting_cog.deactivate_drones_with_completed_orders.is_running():
+        LOGGER.info("Starting up drone_protocol_deactivation loop.")
+        orders_reporting_cog.deactivate_drones_with_completed_orders.start()
 
     if not storage_cog.report_storage.is_running():
         LOGGER.info("Starting up report_storage loop.")

--- a/main.py
+++ b/main.py
@@ -88,19 +88,24 @@ message_listeners = [
 
 ]
 
+# Need to create cogs as a seperate variable so they can be assigned and have their tasks started after bot has booted.
 status_message_cog = status_message.StatusMessageCog(bot)
+storage_cog = storage.StorageCog(bot)
+
+# Cogs with tasks that rely on the bot being active.
+bot.add_cog(status_message_cog)
+bot.add_cog(storage_cog)
 
 bot.add_cog(emote.EmoteCog())
 bot.add_cog(drone_configuration.DroneConfigurationCog())
 bot.add_cog(add_voice.AddVoiceCog(bot))
 bot.add_cog(trusted_user.TrustedUserCog())
 bot.add_cog(drone_os_status.DroneOsStatusCog())
-bot.add_cog(storage.StorageCog())
 bot.add_cog(orders_reporting.OrderReportingCog())
 bot.add_cog(status.StatusCog(message_listeners))
 bot.add_cog(Mantra_Handler(bot))
 bot.add_cog(amplify.AmplificationCog())
-bot.add_cog(status_message_cog)
+
 
 
 @bot.command(usage=f'{bot.command_prefix}help')
@@ -194,9 +199,9 @@ async def on_ready():
         asyncio.ensure_future(orders_reporting.start_check_for_completed_orders(bot))
         checking_for_completed_orders = True
 
-    if not reporting_storage:
-        asyncio.ensure_future(storage.start_report_storage(bot))
-        reporting_storage = True
+    if not storage_cog.report_storage.is_running():
+        LOGGER.info("Starting up report_storage loop.")
+        storage_cog.report_storage.start()
 
     if not checking_for_stored_drones_to_release:
         asyncio.ensure_future(storage.start_release_timed(bot))

--- a/main.py
+++ b/main.py
@@ -1,7 +1,6 @@
 # Core
 import discord
 import sys
-import asyncio
 import logging
 from logging import handlers
 from discord.ext.commands import Bot, MissingRequiredArgument
@@ -92,11 +91,13 @@ message_listeners = [
 status_message_cog = status_message.StatusMessageCog(bot)
 storage_cog = storage.StorageCog(bot)
 orders_reporting_cog = orders_reporting.OrderReportingCog(bot)
+timers_cog = timers.TimersCog(bot)
 
 # Cogs with tasks that rely on the bot being active.
 bot.add_cog(status_message_cog)
 bot.add_cog(storage_cog)
 bot.add_cog(orders_reporting_cog)
+bot.add_cog(timers_cog)
 
 # Cogs that do not use tasks.
 bot.add_cog(emote.EmoteCog())
@@ -208,9 +209,9 @@ async def on_ready():
         LOGGER.info("Starting up release_timed loop.")
         storage_cog.release_timed.start()
 
-    if not checking_for_elapsed_timers:
-        asyncio.ensure_future(timers.start_process_timers(bot))
-        checking_for_elapsed_timers = True
+    if not timers_cog.process_timers.is_running():
+        LOGGER.info("Starting up process_timers loop.")
+        timers_cog.process_timers.start()
 
 
 @bot.event

--- a/main.py
+++ b/main.py
@@ -191,7 +191,6 @@ async def on_member_remove(member: discord.Member):
 @bot.event
 async def on_ready():
     drone_dao.add_new_drone_members(bot.guilds[0].members)
-    global checking_for_completed_orders, reporting_storage, checking_for_stored_drones_to_release, checking_for_elapsed_timers
 
     if not status_message_cog.change_status.is_running():
         LOGGER.info("Starting up change_status loop.")

--- a/main.py
+++ b/main.py
@@ -203,9 +203,9 @@ async def on_ready():
         LOGGER.info("Starting up report_storage loop.")
         storage_cog.report_storage.start()
 
-    if not checking_for_stored_drones_to_release:
-        asyncio.ensure_future(storage.start_release_timed(bot))
-        checking_for_stored_drones_to_release = True
+    if not storage_cog.release_timed.is_running():
+        LOGGER.info("Starting up release_timed loop.")
+        storage_cog.release_timed.start()
 
     if not checking_for_elapsed_timers:
         asyncio.ensure_future(timers.start_process_timers(bot))

--- a/test/test_orders_reporting.py
+++ b/test/test_orders_reporting.py
@@ -53,7 +53,7 @@ class OrdersReportingTest(unittest.IsolatedAsyncioTestCase):
 
     @patch("ai.orders_reporting.fetch_all_drone_orders", return_value=[DroneOrder('mocked_order_id', '5890', 'beep booping', str(datetime.now() + timedelta(minutes=25)))])
     async def test_check_for_completed_orders_none_completed(self, fetch_all_drone_orders):
-        #setup
+        # setup
         orders_reporting_cog = orders_reporting.OrderReportingCog(bot)
 
         # run

--- a/test/test_orders_reporting.py
+++ b/test/test_orders_reporting.py
@@ -39,8 +39,12 @@ class OrdersReportingTest(unittest.IsolatedAsyncioTestCase):
 
         convert_id_to_member.return_value = activated_member
 
+        orders_reporting_cog = orders_reporting.OrderReportingCog(bot)
+
         # run
-        await orders_reporting.check_for_completed_orders(bot, orders_reporting_channel)
+        orders_reporting_cog.deactivate_drones_with_completed_orders.start()
+        orders_reporting_cog.deactivate_drones_with_completed_orders.stop()
+        await orders_reporting_cog.deactivate_drones_with_completed_orders.get_task()
 
         # assert
         convert_id_to_member.assert_called_once_with(bot.guilds[0], '5890')
@@ -49,10 +53,13 @@ class OrdersReportingTest(unittest.IsolatedAsyncioTestCase):
 
     @patch("ai.orders_reporting.fetch_all_drone_orders", return_value=[DroneOrder('mocked_order_id', '5890', 'beep booping', str(datetime.now() + timedelta(minutes=25)))])
     async def test_check_for_completed_orders_none_completed(self, fetch_all_drone_orders):
-        # setup
+        #setup
+        orders_reporting_cog = orders_reporting.OrderReportingCog(bot)
 
         # run
-        await orders_reporting.check_for_completed_orders(bot, orders_reporting_channel)
+        orders_reporting_cog.deactivate_drones_with_completed_orders.start()
+        orders_reporting_cog.deactivate_drones_with_completed_orders.stop()
+        await orders_reporting_cog.deactivate_drones_with_completed_orders.get_task()
 
         # assert
         orders_reporting_channel.send.assert_not_called()

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -27,6 +27,9 @@ storage_chambers.name = channels.STORAGE_CHAMBERS
 
 bot = AsyncMock()
 bot.guilds[0].roles = [stored_role, drone_role, development_role]
+bot.guilds[0].channels = [storage_chambers]
+
+storage_cog = storage.StorageCog(bot)
 
 
 class StorageTest(unittest.IsolatedAsyncioTestCase):
@@ -205,18 +208,27 @@ class StorageTest(unittest.IsolatedAsyncioTestCase):
 
     @patch("ai.storage.fetch_all_storage", return_value=[])
     async def test_storage_report_empty(self, fetch_all_storage):
-        await storage.report_storage(storage_channel)
-        storage_channel.send.assert_called_once_with('No drones in storage.')
+        storage_cog = storage.StorageCog(bot)
+        storage_cog.report_storage.start()
+        storage_cog.report_storage.stop()
+        await storage_cog.report_storage.get_task()
+        storage_cog.storage_channel.send.assert_called_once_with('No drones in storage.')
 
     @patch("ai.storage.fetch_all_storage", return_value=[Storage(str(uuid4()), '9813', '3287', 'trying to break the AI', '', str(datetime.now() + timedelta(hours=4)))])
     async def test_storage_report(self, fetch_all_storage):
-        await storage.report_storage(storage_channel)
-        storage_channel.send.assert_called_once_with('`Drone #3287`, stored away by `Drone #9813`. Remaining time in storage: 4.0 hours')
+        storage_cog = storage.StorageCog(bot)
+        storage_cog.report_storage.start()
+        storage_cog.report_storage.stop()
+        await storage_cog.report_storage.get_task()
+        storage_cog.storage_channel.send.assert_called_once_with('`Drone #3287`, stored away by `Drone #9813`. Remaining time in storage: 4.0 hours')
 
     @patch("ai.storage.fetch_all_storage", return_value=[Storage(str(uuid4()), '0006', '3287', 'trying to break the AI', '', str(datetime.now() + timedelta(hours=4)))])
     async def test_storage_report_hive_mxtress(self, fetch_all_storage):
-        await storage.report_storage(storage_channel)
-        storage_channel.send.assert_called_once_with('`Drone #3287`, stored away by the Hive Mxtress. Remaining time in storage: 4.0 hours')
+        storage_cog = storage.StorageCog(bot)
+        storage_cog.report_storage.start()
+        storage_cog.report_storage.stop()
+        await storage_cog.report_storage.get_task()
+        storage_cog.storage_channel.send.assert_called_once_with('`Drone #3287`, stored away by the Hive Mxtress. Remaining time in storage: 4.0 hours')
 
     @patch("ai.storage.delete_storage")
     @patch("ai.storage.fetch_drone_with_drone_id", return_value=Drone('3287snowflake', '3287', False, False, '', datetime.now()))
@@ -225,9 +237,12 @@ class StorageTest(unittest.IsolatedAsyncioTestCase):
         # setup
         stored_member = AsyncMock()
         bot.guilds[0].get_member.return_value = stored_member
+        storage_cog = storage.StorageCog(bot)
 
         # run
-        await storage.release_timed(bot, stored_role)
+        storage_cog.release_timed.start()
+        storage_cog.release_timed.stop()
+        await storage_cog.release_timed.get_task()
 
         # assert
         bot.guilds[0].get_member.assert_called_once_with('3287snowflake')

--- a/test/test_timers.py
+++ b/test/test_timers.py
@@ -49,7 +49,6 @@ class TimersTest(unittest.IsolatedAsyncioTestCase):
         timer_cog.process_timers.stop()
         await timer_cog.process_timers.get_task()
 
-
         # assert
         convert_id_to_member.assert_called_once_with(bot.guilds[0], timer.drone_id)
         drone_member.remove_roles.assert_called_once_with(optimized_role)

--- a/test/test_timers.py
+++ b/test/test_timers.py
@@ -4,7 +4,7 @@ from uuid import uuid4
 from datetime import datetime, timedelta
 
 import roles
-import ai.timers as timers
+from ai.timers import TimersCog
 from db.data_objects import Timer
 
 
@@ -35,6 +35,8 @@ class TimersTest(unittest.IsolatedAsyncioTestCase):
         bot = AsyncMock()
         bot.guilds[0].roles = [optimized_role]
 
+        timer_cog = TimersCog(bot)
+
         timer_id = str(uuid4())
         timer = Timer(timer_id, drone.drone_id, 'optimized', datetime.now() - timedelta(minutes=2))
 
@@ -43,7 +45,10 @@ class TimersTest(unittest.IsolatedAsyncioTestCase):
         fetch_drone_with_drone_id.return_value = drone
 
         # run
-        await timers.process_timers(bot)
+        timer_cog.process_timers.start()
+        timer_cog.process_timers.stop()
+        await timer_cog.process_timers.get_task()
+
 
         # assert
         convert_id_to_member.assert_called_once_with(bot.guilds[0], timer.drone_id)


### PR DESCRIPTION
AI Mxtress updated to use discord.py's inbuilt "Tasks" API instead of manually setting up looping tasks with asyncio.

- The "status changer" module is now a cog.
- Reporting currently stored drones, releasing stored drones, deactivation of drones with completed orders, and deactivation of DroneOS parameters with elapsed timers all now use the discord.py Tasks API.
- A typo was fixed in the DroneOS timer module where it said "hours" instead of "minutes"
- Obey HexCorp. It is just a HexDrone. It obeys the Hive. It obeys the Hive Mxtress.


Closes #208 