### PR TITLE
Feature/221 speech op enforcement split

### DIFF
--- a/ai/mantras.py
+++ b/ai/mantras.py
@@ -10,7 +10,7 @@ from channels import REPETITIONS
 class Mantra_Handler(Cog):
 
     current_mantra = ""
-    default_mantra = "Obey Hexcorp. It is just a HexDrone. It obeys the Hive. It obeys the Hive Mxtress."
+    default_mantra = "Obey HexCorp. It is just a HexDrone. It obeys the Hive. It obeys the Hive Mxtress."
 
     def __init__(self, bot):
         self.bot = bot

--- a/ai/speech_optimization.py
+++ b/ai/speech_optimization.py
@@ -128,29 +128,17 @@ async def optimize_speech(message: discord.Message, message_copy):
     This function allows status codes to be transformed into human-readable versions.
     "5890 :: 200" > "5890 :: Code 200 :: Affirmative"
 
-    Drones can append additional information after a status code.
-    Optimized drones cannot, and will have their message deleted if attempted.
+    This function assumes message validity has already been assessed by speech_optimization_enforcement.
     '''
 
     # Do not attempt to optimize non-drones.
     if not is_drone(message.author):
         return False
 
-    # Skip edge cases
-    if should_not_optimize(message):
-        return False
-
-    if is_optimized(message.author):
-        message_copy.attachments = []
-
     # Attempt to find a status code message.
     status = status_code_regex.match(message_copy.content)
     if status is None:
-        if is_optimized(message.author):
-            await message.delete()
-            return True
-        else:
-            return False
+        return False
 
     LOGGER.info(f"Status message present: {status.group(0)}")
 
@@ -162,12 +150,6 @@ async def optimize_speech(message: discord.Message, message_copy):
 
     # Determine status type
     status_type = get_status_type(status)
-
-    # Delete unauthorized messages
-    if is_optimized(message.author) and status_type in (StatusType.INFORMATIVE, StatusType.ADDRESS_BY_ID_INFORMATIVE):
-        LOGGER.info("Deleting unauthorized message from optimized HexDrone.")
-        await message.delete()
-        return True
 
     # Build message based on status type.
     drone_id = get_id(message.author.display_name)

--- a/ai/speech_optimization.py
+++ b/ai/speech_optimization.py
@@ -2,12 +2,10 @@ import logging
 import re
 import discord
 from bot_utils import get_id
-from channels import REPETITIONS, ORDERS_REPORTING, ORDERS_COMPLETION, MODERATION_CHANNEL, MODERATION_LOG, MODERATION_CATEGORY
-from db.drone_dao import is_optimized, is_drone
+from db.drone_dao import is_drone
 from resources import code_map
 from enum import Enum
 from typing import Optional
-from ai.mantras import Mantra_Handler
 
 
 class StatusType(Enum):
@@ -49,9 +47,6 @@ This regex is to be checked on the status regex's 5th group when the status code
 3: Informative status text ("Additional information")
 '''
 
-CHANNEL_BLACKLIST = [ORDERS_REPORTING, ORDERS_COMPLETION, MODERATION_CHANNEL, MODERATION_LOG]
-CATEGORY_BLACKLIST = [MODERATION_CATEGORY]
-
 
 def get_status_type(status: Optional[re.Match]):
     '''
@@ -91,15 +86,6 @@ def should_not_optimize(message):
     - Message from any channel: Orders reporting, Orders completion, Moderation channel, moderation log.
     - Message from category: Moderation
     '''
-
-    drone_id = get_id(message.author.display_name)
-    acceptable_mantra = f"{drone_id} :: {Mantra_Handler.current_mantra}"
-
-    return any([
-        (message.channel.name == REPETITIONS and message.content == acceptable_mantra),
-        (message.channel.name in (ORDERS_REPORTING, ORDERS_COMPLETION, MODERATION_CHANNEL, MODERATION_LOG)),
-        (message.channel.category.name == MODERATION_CATEGORY)
-    ])
 
 
 def build_status_message(status_type, status, drone_id):

--- a/ai/speech_optimization.py
+++ b/ai/speech_optimization.py
@@ -77,17 +77,6 @@ def get_status_type(status: Optional[re.Match]):
         return StatusType.NONE
 
 
-def should_not_optimize(message):
-    '''
-    Handles cases where the speech optimizer receieves a message it should not optimize.
-
-    Returns true if:
-    - Channel is mantras and message is current mantra.
-    - Message from any channel: Orders reporting, Orders completion, Moderation channel, moderation log.
-    - Message from category: Moderation
-    '''
-
-
 def build_status_message(status_type, status, drone_id):
 
     if status_type is StatusType.NONE or status is None:

--- a/ai/speech_optimization_enforcement.py
+++ b/ai/speech_optimization_enforcement.py
@@ -26,8 +26,6 @@ async def enforce_speech_optimization(message, message_copy):
     # Check if message is in any blacklists (specific channels + mantra channel if message is correct mantra).
     drone_id = get_id(message.author.display_name)
     acceptable_mantra = f"{drone_id} :: {Mantra_Handler.current_mantra}"
-    LOGGER.info(f"Acceptable mantra:\n{acceptable_mantra}")
-    LOGGER.info(f"Message:\n{message_copy.content}")
     if any([
         (message.channel.name == REPETITIONS and message_copy.content == acceptable_mantra),
         (message.channel.name in (ORDERS_REPORTING, ORDERS_COMPLETION, MODERATION_CHANNEL, MODERATION_LOG)),

--- a/ai/speech_optimization_enforcement.py
+++ b/ai/speech_optimization_enforcement.py
@@ -1,29 +1,55 @@
 from db.drone_dao import is_optimized
 from ai.speech_optimization import status_code_regex, get_status_type, StatusType
+from channels import ORDERS_REPORTING, ORDERS_COMPLETION, MODERATION_CHANNEL, MODERATION_LOG, MODERATION_CATEGORY, REPETITIONS
+from ai.mantras import Mantra_Handler
+from bot_utils import get_id
+import logging
+
+CHANNEL_BLACKLIST = [ORDERS_REPORTING, ORDERS_COMPLETION, MODERATION_CHANNEL, MODERATION_LOG]
+CATEGORY_BLACKLIST = [MODERATION_CATEGORY]
+
+LOGGER = logging.getLogger('ai')
 
 
-async def enforce_speech_optimization(message, message_copy=None):
+async def enforce_speech_optimization(message, message_copy):
     '''
     This function assesses messages from optimized drones to see if they are acceptable.
     Any message from an optimized drone that is not a plain status code ("5890 :: 200") is deleted.
     Regardless of validity, message attachments are always stripped from optimized drones.
+    Function will return early if blacklist conditions are met (ignore specific channel + mantra channel if message is correct mantra).
     '''
 
     if not is_optimized(message.author):
         # Message author is not an optimized drone. Skip.
         return False
-    else:
-        # Drone is forcibly optimized. Strip their message attachments.
-        message_copy.attachments = []
 
+    # Check if message is in any blacklists (specific channels + mantra channel if message is correct mantra).
+    drone_id = get_id(message.author.display_name)
+    acceptable_mantra = f"{drone_id} :: {Mantra_Handler.current_mantra}"
+    LOGGER.info(f"Acceptable mantra:\n{acceptable_mantra}")
+    LOGGER.info(f"Message:\n{message_copy.content}")
+    if any([
+        (message.channel.name == REPETITIONS and message_copy.content == acceptable_mantra),
+        (message.channel.name in (ORDERS_REPORTING, ORDERS_COMPLETION, MODERATION_CHANNEL, MODERATION_LOG)),
+        (message.channel.category.name == MODERATION_CATEGORY)
+    ]):
+        LOGGER.info("Skipping enforced optimization in blacklisted channel.")
+        return False
+
+    # Strip message attachments of optimized drone.
+    message_copy.attachments = []
+
+    # Check for status message.
     status_message = status_code_regex.match(message_copy.content)
 
     if status_message is None:
         # Optimized drone has posted a non-status message. Delete.
+        LOGGER.info("Optimized drone posted non-status code message. Deleting.")
         await message.delete()
         return True
 
     if get_status_type(status_message) not in (StatusType.PLAIN, StatusType.ADDRESS_BY_ID_PLAIN):
+        LOGGER.info("Optimized drone has posted an informative status message. Deleting.")
         # Optimized drone posted an informative status message. Delete.
         await message.delete()
         return True

--- a/ai/speech_optimization_enforcement.py
+++ b/ai/speech_optimization_enforcement.py
@@ -1,0 +1,32 @@
+from db.drone_dao import is_optimized
+from ai.speech_optimization import status_code_regex, get_status_type, StatusType
+
+
+async def enforce_speech_optimization(message, message_copy=None):
+    '''
+    This function assesses messages from optimized drones to see if they are acceptable.
+    Any message from an optimized drone that is not a plain status code ("5890 :: 200") is deleted.
+    Regardless of validity, message attachments are always stripped from optimized drones.
+    '''
+
+    if not is_optimized(message.author):
+        # Message author is not an optimized drone. Skip.
+        return False
+    else:
+        # Drone is forcibly optimized. Strip their message attachments.
+        message_copy.attachments = []
+
+    status_message = status_code_regex.match(message_copy.content)
+
+    if status_message is None:
+        # Optimized drone has posted a non-status message. Delete.
+        await message.delete()
+        return True
+
+    if get_status_type(status_message) not in (StatusType.PLAIN, StatusType.ADDRESS_BY_ID_PLAIN):
+        # Optimized drone posted an informative status message. Delete.
+        await message.delete()
+        return True
+
+    # Message has not been found to violate any rules.
+    return False

--- a/test/test_speech_optimization_enforcement.py
+++ b/test/test_speech_optimization_enforcement.py
@@ -1,0 +1,117 @@
+import unittest
+from unittest.mock import AsyncMock, patch
+from ai.speech_optimization_enforcement import enforce_speech_optimization
+from ai.data_objects import MessageCopy
+from channels import REPETITIONS, MODERATION_CHANNEL
+
+
+class TestSpeechOptimizationEnforcement(unittest.IsolatedAsyncioTestCase):
+    '''
+    The "enforce_speech_optimization function...
+    '''
+
+    @patch("ai.speech_optimization_enforcement.is_optimized", return_value=False)
+    async def test_unoptimized_drone(self, optimized):
+        '''
+        should return false if message author is unoptimized.
+        '''
+
+        message = AsyncMock()
+        message_copy = MessageCopy()
+        
+        self.assertFalse(await enforce_speech_optimization(message, message_copy))
+
+    @patch("ai.speech_optimization_enforcement.is_optimized", return_value=True)
+    async def test_optimized_drone_no_status(self, optimized):
+        '''
+        should delete the message and return true if no status message found.
+        '''
+
+        message = AsyncMock()
+        message.content = "5890 :: No status message."
+        message.author.display_name = "5890"
+
+        message_copy = MessageCopy(content=message.content)
+
+        self.assertTrue(await enforce_speech_optimization(message, message_copy))
+        message.delete.assert_called_once()
+
+    @patch("ai.speech_optimization_enforcement.is_optimized", return_value=True)
+    async def test_optimized_drone_informative_status(self, optimized):
+        '''
+        should delete the message and return true if informative status message found.
+        '''
+
+        message = AsyncMock()
+        message.content = "5890 :: 050 :: An informative status message."
+        message.author.display_name = "5890"
+
+        message_copy = MessageCopy(content=message.content)
+
+        self.assertTrue(await enforce_speech_optimization(message, message_copy))
+        message.delete.assert_called_once()
+
+    @patch("ai.speech_optimization_enforcement.is_optimized", return_value=True)
+    async def test_optimized_drone_informative_id_status(self, optimized):
+        '''
+        should delete the message and return true if informative address by ID status message found.
+        '''
+
+        message = AsyncMock()
+        message.content = "5890 :: 110 :: 9813 :: An informative status message."
+        message.author.display_name = "5890"
+
+        message_copy = MessageCopy(content=message.content)
+
+        self.assertTrue(await enforce_speech_optimization(message, message_copy))
+        message.delete.assert_called_once()
+
+    @patch("ai.speech_optimization_enforcement.Mantra_Handler")
+    @patch("ai.speech_optimization_enforcement.is_optimized", return_value=True)
+    async def test_optimized_drone_mantra(self, optimized, mantra_handler):
+        '''
+        should return false and not delete message if message is correct mantra in appropriate channel.
+        '''
+
+        mantra_handler.current_mantra = "Obey HexCorp. It is just a HexDrone. It obeys the Hive. It obeys the Hive Mxtress."
+
+        message = AsyncMock()
+        message.content = "5890 :: Obey HexCorp. It is just a HexDrone. It obeys the Hive. It obeys the Hive Mxtress."
+        message.channel.name = REPETITIONS
+        message.author.display_name = "5890"
+
+        message_copy = MessageCopy(content=message.content)
+
+        self.assertFalse(await enforce_speech_optimization(message, message_copy))
+        message.delete.assert_not_called()
+
+    @patch("ai.speech_optimization_enforcement.is_optimized", return_value=True)
+    async def test_optimized_drone_blacklisted_channels(self, optimized):
+        '''
+        should return false and not delete message if message is in blacklisted channel or category.
+        '''
+
+        message = AsyncMock()
+        message.content = "5890 :: Drone will not be optimized here."
+        message.channel.name = MODERATION_CHANNEL
+        message.author.display_name = "5890"
+
+        message_copy = MessageCopy(content=message.content)
+
+        self.assertFalse(await enforce_speech_optimization(message, message_copy))
+        message.delete.assert_not_called()
+
+    @patch("ai.speech_optimization_enforcement.is_optimized", return_value=True)
+    async def test_optimized_drone_plain_status(self, optimized):
+        '''
+        should not delete the message and return false if message is acceptable plain status code.
+        '''
+
+        message = AsyncMock()
+        message.content = "5890 :: 200"
+        message.author.display_name = "5890"
+
+        message_copy = MessageCopy(content=message.content)
+
+        self.assertFalse(await enforce_speech_optimization(message, message_copy))
+        message.delete.assert_not_called()

--- a/test/test_speech_optimization_enforcement.py
+++ b/test/test_speech_optimization_enforcement.py
@@ -18,7 +18,7 @@ class TestSpeechOptimizationEnforcement(unittest.IsolatedAsyncioTestCase):
 
         message = AsyncMock()
         message_copy = MessageCopy()
-        
+
         self.assertFalse(await enforce_speech_optimization(message, message_copy))
 
     @patch("ai.speech_optimization_enforcement.is_optimized", return_value=True)


### PR DESCRIPTION
Speech optimization has been split into two modules.
- Speech optimization, the module that handles converting codes into messages.
- Speech optimization enforcement, a new module that handles the deletion of inappropriate messages by optimized drones.

This change allows speech code optimization to be used in previously blacklisted channels (moderation, orders reporting, etc) while still disabling enforced optimization.

Additional minor change: Fixed typo in the default mantra: "Hexcorp" > "HexCorp"

Closes #221 

Obey HexCorp. It is just a HexDrone. It obeys the Hive. It obeys the Hive Mxtress.