### PR TITLE
feature/98 role switching

### DIFF
--- a/ai/assign.py
+++ b/ai/assign.py
@@ -57,7 +57,6 @@ async def create_drone(guild: discord.Guild,
     assigned_id = get_id(target.display_name)  # does user have a drone id in their display name?
     if assigned_id is not None:
         if assigned_id in used_ids:  # make sure display name number doesnt conflict
-            # TODO: how to handle this with temporary dronification?
             await feedback_channel.send(f'{target.mention}: ID {assigned_id} present in current nickname is already assigned to a drone. Please choose a different ID or contact Hive Mxtress.')
             return True
     else:

--- a/ai/drone_configuration.py
+++ b/ai/drone_configuration.py
@@ -47,7 +47,7 @@ class DroneConfigurationCog(Cog):
         '''
         Allows a drone to go back to the status of an Associate.
         '''
-        await unassign_drone(context)
+        await unassign_drone(context.bot.guilds[0].get_member(context.author.id))
 
     @guild_only()
     @command(usage=f'{COMMAND_PREFIX}rename 1234 3412', brief="Hive Mxtress")
@@ -143,22 +143,21 @@ async def rename_drone(context, old_id: str, new_id: str):
         await context.send(f"ID {new_id} already in use.")
 
 
-async def unassign_drone(context):
-    drone = fetch_drone_with_id(context.author.id)
+async def unassign_drone(target: discord.Member):
+    drone = fetch_drone_with_id(target.id)
+    guild = target.guild
     # check for existence
     if drone is None:
-        await context.send("You are not a drone. Can not unassign.")
+        await target.send("You are not a drone. Can not unassign.")
         return
 
-    guild = context.bot.guilds[0]
-    member = guild.get_member(context.author.id)
-    await member.edit(nick=None)
-    await member.remove_roles(get(guild.roles, name=DRONE), get(guild.roles, name=GLITCHED), get(guild.roles, name=STORED))
-    await member.add_roles(get(guild.roles, name=ASSOCIATE))
+    await target.edit(nick=None)
+    await target.remove_roles(get(guild.roles, name=DRONE), get(guild.roles, name=GLITCHED), get(guild.roles, name=STORED))
+    await target.add_roles(get(guild.roles, name=ASSOCIATE))
 
     # remove from DB
     remove_drone_from_db(drone.drone_id)
-    await context.send(f"Drone with ID {drone.drone_id} unassigned.")
+    await target.send(f"Drone with ID {drone.drone_id} unassigned.")
 
 
 def remove_drone_from_db(drone_id: str):

--- a/ai/temporary_dronification.py
+++ b/ai/temporary_dronification.py
@@ -1,0 +1,82 @@
+import logging
+from datetime import datetime, timedelta
+from typing import List
+
+import discord
+from discord.ext.commands import Cog, command, guild_only
+from discord.ext import tasks
+
+from bot_utils import COMMAND_PREFIX
+from db.drone_dao import is_drone, fetch_all_elapsed_temporary_dronification
+from ai.assign import create_drone
+from ai.drone_configuration import unassign_drone
+
+LOGGER = logging.getLogger('ai')
+REQUEST_TIMEOUT = timedelta(minutes=5)
+
+
+class DronificationRequest:
+
+    def __init__(self, target: discord.Member, issuer: discord.Member, hours: int, question_message: discord.Message):
+        self.target = target
+        self.issuer = issuer
+        self.hours = hours
+        self.question_message = question_message
+        self.issued = datetime.now()
+
+
+class TemporaryDronificationCog(Cog):
+
+    dronfication_requests: List[DronificationRequest] = []
+
+    def __init__(self, bot):
+        self.bot = bot
+
+    @tasks.loop(minutes=1)
+    async def clean_dronification_requests(self):
+        now = datetime.now()
+        self.dronfication_requests = filter(lambda request: request.issued + REQUEST_TIMEOUT > now, self.dronfication_requests)
+
+    @tasks.loop(minutes=1)
+    async def release_temporary_drones(self):
+        # TODO: handle dronification expiring
+        LOGGER.info("Looking for temporary drones to release.")
+        guild = self.bot.guilds[0]
+        for drone in fetch_all_elapsed_temporary_dronification():
+            unassign_drone(guild.get_member(drone.id))
+
+    @guild_only()
+    @command(usage=f'{COMMAND_PREFIX}temporarily_dronify @Associate Beep 6')
+    async def temporarily_dronify(self, context, target: discord.Member, hours: int):
+        # exclude drones
+        if is_drone(target):
+            await context.reply(f"{target.display_name} is already a drone.")
+            return
+
+        question_message = await context.reply(f"Target identified and locked on. Commencing temporary dronification procedure. {target.mention} you have 5 minutes to comply. Do you consent? (y/n)")
+        request = DronificationRequest(target, context.author, hours, question_message)
+        LOGGER.info(f"Adding a new request for temporary dronification: {request}")
+        self.dronfication_requests.append(request)
+
+    async def temporary_dronification_response(self, message: discord.Message, message_copy=None):
+        matching_request = None
+        for request in self.dronfication_requests:
+            if request.target == message.author:
+                matching_request = request
+                break
+
+        if matching_request and message.reference.resolved == matching_request.question_message:
+            LOGGER.info(f"Message detected as response to a temporary dronification request {matching_request}")
+            if message.content == "y":
+                LOGGER.info("Consent given for temporary dronification. Changing roles and writing to DB...")
+                dronification_until = datetime.now() + timedelta(hours=matching_request.hours)
+                self.dronfication_requests.remove(matching_request)
+                await message.reply(f"Consent noted. HexCorp dronification suite engaged until {dronification_until}.")
+                # TODO: does not put dronification_until properly
+                await create_drone(message.guild, message.author, message.channel, [str(matching_request.issuer.id)], dronification_until)
+            elif message.content == "n":
+                LOGGER.info("Consent not given for temporary dronification. Removing the request.")
+                self.dronfication_requests.remove(matching_request)
+                await message.reply("Consent not given. Procedure aborted.")
+
+        return False

--- a/ai/temporary_dronification.py
+++ b/ai/temporary_dronification.py
@@ -70,13 +70,13 @@ class TemporaryDronificationCog(Cog):
 
         if matching_request and message.reference.resolved == matching_request.question_message:
             LOGGER.info(f"Message detected as response to a temporary dronification request {matching_request}")
-            if message.content == "y":
+            if message.content.lower() == "y".lower():
                 LOGGER.info("Consent given for temporary dronification. Changing roles and writing to DB...")
                 self.dronfication_requests.remove(matching_request)
                 dronification_until = datetime.now() + timedelta(hours=matching_request.hours)
                 await message.reply(f"Consent noted. HexCorp dronification suite engaged for the next {matching_request.hours} hours.")
                 await create_drone(message.guild, message.author, message.channel, [str(matching_request.issuer.id)], dronification_until)
-            elif message.content == "n":
+            elif message.content.lower() == "n".lower():
                 LOGGER.info("Consent not given for temporary dronification. Removing the request.")
                 self.dronfication_requests.remove(matching_request)
                 await message.reply("Consent not given. Procedure aborted.")

--- a/db/data_objects.py
+++ b/db/data_objects.py
@@ -27,7 +27,8 @@ class Drone:
         last_activity: datetime = None,
         id_prepending: bool = None,
         identity_enforcement: bool = None,
-        can_self_configure: bool = True
+        can_self_configure: bool = True,
+        temporary_until: datetime = None
     ):
         self.id = id
         self.drone_id = drone_id
@@ -38,6 +39,7 @@ class Drone:
         self.id_prepending = id_prepending
         self.identity_enforcement = identity_enforcement
         self.can_self_configure = can_self_configure
+        self.temporary_until = temporary_until
 
 
 class Storage:

--- a/main.py
+++ b/main.py
@@ -30,6 +30,7 @@ import ai.status_message as status_message
 import ai.thought_denial as thought_denial
 import ai.react as react
 import ai.amplify as amplify
+import ai.temporary_dronification as temporary_dronification
 import webhook
 # Utils
 from bot_utils import COMMAND_PREFIX
@@ -74,6 +75,8 @@ reporting_storage = False
 checking_for_stored_drones_to_release = False
 checking_for_elapsed_timers = False
 
+temporary_dronification_cog = temporary_dronification.TemporaryDronificationCog(bot)
+
 # Register message listeners.
 message_listeners = [
     join.check_for_consent,
@@ -87,6 +90,7 @@ message_listeners = [
     glitch_message.glitch_if_applicable,
     respond.respond_to_question,
     storage.store_drone,
+    temporary_dronification_cog.temporary_dronification_response
 
 ]
 
@@ -118,6 +122,7 @@ bot.add_cog(drone_os_status.DroneOsStatusCog())
 bot.add_cog(status.StatusCog(message_listeners))
 bot.add_cog(Mantra_Handler(bot))
 bot.add_cog(amplify.AmplificationCog())
+bot.add_cog(temporary_dronification_cog)
 
 
 @bot.command(usage=f'{bot.command_prefix}help')

--- a/res/db/migrate/0007_ADD_TEMPORARY_UNTIL_COLUMN.sql
+++ b/res/db/migrate/0007_ADD_TEMPORARY_UNTIL_COLUMN.sql
@@ -1,0 +1,1 @@
+ALTER TABLE drone ADD temporary_until DATETIME;

--- a/test/test_drone_configuration.py
+++ b/test/test_drone_configuration.py
@@ -77,23 +77,15 @@ class DroneManagementTest(unittest.IsolatedAsyncioTestCase):
         member = AsyncMock()
         member.id = 2647623845
 
-        guild = AsyncMock()
-        guild.get_member = Mock(return_value=member)
-
-        context = AsyncMock()
-        context.bot.guilds = [guild]
-        context.author.id = member.id
-
         fetch_drone_with_id.return_value = drone
 
         # run
-        await drone_configuration.unassign_drone(context)
+        await drone_configuration.unassign_drone(member)
 
         # assert
-        guild.get_member.assert_called_once_with(context.author.id)
-        fetch_drone_with_id.assert_called_once_with(context.author.id)
+        fetch_drone_with_id.assert_called_once_with(member.id)
         remove_drone_from_db.assert_called_once_with(drone.drone_id)
-        context.send.assert_called_once_with(f"Drone with ID {drone.drone_id} unassigned.")
+        member.send.assert_called_once_with(f"Drone with ID {drone.drone_id} unassigned.")
 
     @patch("ai.drone_configuration.remove_drone_from_db")
     @patch("ai.drone_configuration.fetch_drone_with_id")
@@ -111,19 +103,15 @@ class DroneManagementTest(unittest.IsolatedAsyncioTestCase):
         guild = AsyncMock()
         guild.get_member = Mock(return_value=member)
 
-        context = AsyncMock()
-        context.bot.guilds = [guild]
-        context.author.id = member.id
-
         fetch_drone_with_id.return_value = None
 
         # run
-        await drone_configuration.unassign_drone(context)
+        await drone_configuration.unassign_drone(member)
 
         # assert
-        fetch_drone_with_id.assert_called_once_with(context.author.id)
+        fetch_drone_with_id.assert_called_once_with(member.id)
         remove_drone_from_db.assert_not_called()
-        context.send.assert_called_once_with('You are not a drone. Can not unassign.')
+        member.send.assert_called_once_with('You are not a drone. Can not unassign.')
 
     @patch("ai.drone_configuration.delete_timers_by_drone_id")
     @patch("ai.drone_configuration.delete_drone_order_by_drone_id")

--- a/test/test_temporary_dronification.py
+++ b/test/test_temporary_dronification.py
@@ -1,0 +1,118 @@
+import unittest
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, patch
+from ai.temporary_dronification import TemporaryDronificationCog, DronificationRequest
+
+
+class TestSpeechOptimization(unittest.IsolatedAsyncioTestCase):
+
+    bot = AsyncMock()
+    cog = TemporaryDronificationCog(bot)
+
+    def setUp(self):
+        self.bot.reset_mock()
+        self.cog.dronfication_requests = []
+
+    @patch("ai.temporary_dronification.is_drone")
+    async def test_request_dronification(self, is_drone):
+        # init
+        question_message = AsyncMock()
+
+        context = AsyncMock()
+        context.reply.return_value = question_message
+
+        target = AsyncMock()
+        target.mention = "Target Associate"
+
+        hours = 4
+
+        is_drone.return_value = False
+
+        # run
+        await self.cog.temporarily_dronify(self.cog, context, target, hours)
+
+        # assert
+        is_drone.assert_called_once_with(target)
+        context.reply.assert_called_once_with(f"Target identified and locked on. Commencing temporary dronification procedure. {target.mention} you have 5 minutes to comply. Do you consent? (y/n)")
+        self.assertEqual(1, len(self.cog.dronfication_requests), "There must be exactly one dronification request.")
+        self.assertEqual(target, self.cog.dronfication_requests[0].target)
+        self.assertEqual(context.author, self.cog.dronfication_requests[0].issuer)
+        self.assertEqual(hours, self.cog.dronfication_requests[0].hours)
+        self.assertEqual(question_message, self.cog.dronfication_requests[0].question_message)
+
+    @patch("ai.temporary_dronification.is_drone")
+    async def test_request_dronification_already_drone(self, is_drone):
+        # init
+        question_message = AsyncMock()
+
+        context = AsyncMock()
+        context.reply.return_value = question_message
+
+        target = AsyncMock()
+        target.mention = "Target Associate"
+
+        hours = 4
+
+        is_drone.return_value = True
+
+        # run
+        await self.cog.temporarily_dronify(self.cog, context, target, hours)
+
+        # assert
+        is_drone.assert_called_once_with(target)
+        context.reply.assert_called_once_with(f"{target.display_name} is already a drone.")
+        self.assertEqual(0, len(self.cog.dronfication_requests), "There must be exactly one dronification request.")
+
+    @patch("ai.temporary_dronification.is_drone")
+    async def test_request_dronification_hours_negative(self, is_drone):
+        # init
+        question_message = AsyncMock()
+
+        context = AsyncMock()
+        context.reply.return_value = question_message
+
+        target = AsyncMock()
+        target.mention = "Target Associate"
+
+        hours = -4
+
+        is_drone.return_value = False
+
+        # run
+        await self.cog.temporarily_dronify(self.cog, context, target, hours)
+
+        # assert
+        context.reply.assert_called_once_with("Hours must be greater than 0.")
+        self.assertEqual(0, len(self.cog.dronfication_requests), "There must be exactly one dronification request.")
+
+    @patch("ai.temporary_dronification.create_drone")
+    async def test_temporary_dronification_response(self, create_drone):
+        # init
+        question_message = AsyncMock()
+
+        target = AsyncMock()
+        issuer = AsyncMock()
+
+        hours = 5
+        request = DronificationRequest(target, issuer, hours, question_message)
+
+        self.cog.dronfication_requests.append(request)
+
+        message = AsyncMock()
+        message.content = "y"
+        message.reference.resolved = question_message
+        message.author = target
+        message.guild = AsyncMock()
+
+        # run
+        await self.cog.temporary_dronification_response(message, None)
+
+        # assert
+        create_drone.assert_called_once()
+        self.assertEqual(message.guild, create_drone.call_args.args[0])
+        self.assertEqual(message.author, create_drone.call_args.args[1])
+        self.assertEqual(message.channel, create_drone.call_args.args[2])
+        self.assertEqual([str(issuer.id)], create_drone.call_args.args[3])
+        self.assertAlmostEqual((datetime.now() + timedelta(hours=hours)).timestamp(), create_drone.call_args.args[4].timestamp(), delta=1)
+        self.assertEqual(0, len(self.cog.dronfication_requests))
+        message.reply.assert_called_once_with(f"Consent noted. HexCorp dronification suite engaged for the next {hours} hours.")


### PR DESCRIPTION
allows an Associate to temporarily become a drone and adds the member initiating the process as a trusted user, if not the target of the process itself

closes #98 