### PR TITLE
identity_enforcable function now checks if user is drone in the database rather than checking if they have the Drone role.

### DIFF
--- a/ai/amplify.py
+++ b/ai/amplify.py
@@ -6,8 +6,7 @@ from channels import OFFICE
 from discord.ext.commands import Cog, command, guild_only
 from resources import DRONE_AVATAR
 from roles import HIVE_MXTRESS, has_role
-
-import ai.identity_enforcement as identity_enforcement
+from ai.identity_enforcement import identity_enforcable
 
 
 class AmplificationCog(Cog):
@@ -28,6 +27,6 @@ class AmplificationCog(Cog):
         for drone in member_drones:
             await webhook.proxy_message_by_webhook(message_content=f"{get_id(drone.display_name)} :: {message}",
                                                    message_username=drone.display_name,
-                                                   message_avatar=drone.avatar_url if not identity_enforcement.identity_enforcable(drone, channel=target_channel) else DRONE_AVATAR,
+                                                   message_avatar=drone.avatar_url if not identity_enforcable(drone, channel=target_channel) else DRONE_AVATAR,
                                                    webhook=channel_webhook)
         return True

--- a/ai/identity_enforcement.py
+++ b/ai/identity_enforcement.py
@@ -3,7 +3,7 @@ import discord
 from channels import DRONE_HIVE_CHANNELS
 from resources import DRONE_AVATAR
 from roles import has_role, DRONE
-from db.drone_dao import is_identity_enforced
+from db.drone_dao import is_identity_enforced, is_drone
 
 LOGGER = logging.getLogger('ai')
 
@@ -15,12 +15,12 @@ async def enforce_identity(message: discord.Message, message_copy):
 
 def identity_enforcable(member: discord.Member, context=None, channel=None):
     '''
-    Takes a context or channel object and uses it to check if an identity should be enforced.
+    Takes a context or channel object and uses it to check if the identity of a user should be enforced.
     '''
 
     if context is not None:
-        return has_role(member, DRONE) and (context.channel.name in DRONE_HIVE_CHANNELS or is_identity_enforced(member))
+        return is_drone(member) and (context.channel.name in DRONE_HIVE_CHANNELS or is_identity_enforced(member))
     elif channel is not None:
-        return has_role(member, DRONE) and (channel.name in DRONE_HIVE_CHANNELS or is_identity_enforced(member))
+        return is_drone(member) and (channel.name in DRONE_HIVE_CHANNELS or is_identity_enforced(member))
     else:
         raise ValueError("identity_enforceable must be provided a context or channel object.")

--- a/ai/identity_enforcement.py
+++ b/ai/identity_enforcement.py
@@ -2,7 +2,6 @@ import logging
 import discord
 from channels import DRONE_HIVE_CHANNELS
 from resources import DRONE_AVATAR
-from roles import has_role, DRONE
 from db.drone_dao import is_identity_enforced, is_drone
 
 LOGGER = logging.getLogger('ai')

--- a/test/test_amplify.py
+++ b/test/test_amplify.py
@@ -9,11 +9,12 @@ class TestAmplify(unittest.IsolatedAsyncioTestCase):
     The amplify command...
     '''
 
+    @patch("ai.amplify.identity_enforcable", return_value=False)
     @patch("ai.amplify.has_role", return_value=True)
     @patch("ai.amplify.webhook.get_webhook_for_channel")
     @patch("ai.amplify.id_converter.convert_ids_to_members")
     @patch("ai.amplify.webhook.proxy_message_by_webhook")
-    async def test_webhook_called_with_appropriate_message(self, webhook_proxy, id_converter, get_webhook, has_role):
+    async def test_webhook_called_with_appropriate_message(self, webhook_proxy, id_converter, get_webhook, has_role, identity_enforceable):
         '''
         should call proxy_message_by_webhook an amount of times equal to unique drones specified. Each message should be prepended with each drones ID.
         '''


### PR DESCRIPTION
Fixes #228 
Hive Mxtress toggled configuration of a drone in storage, which meant their "optimization active" message didn't have the uniform portrait because storage strips drones of their roles.