### PR TITLE
Speech Optimization module technical debt payment

### DIFF
--- a/ai/speech_optimization.py
+++ b/ai/speech_optimization.py
@@ -63,7 +63,7 @@ def get_status_type(message: str):
             return (StatusType.ADDRESS_BY_ID_INFORMATIVE, code_match, address_match)
         else:
             return (StatusType.ADDRESS_BY_ID_PLAIN, code_match, address_match)
-    
+
     elif code_match.group(4) is not None:
         return (StatusType.INFORMATIVE, code_match, None)
     else:

--- a/ai/speech_optimization.py
+++ b/ai/speech_optimization.py
@@ -5,7 +5,6 @@ from bot_utils import get_id
 from db.drone_dao import is_drone
 from resources import code_map
 from enum import Enum
-from typing import Optional
 
 
 class StatusType(Enum):
@@ -38,7 +37,7 @@ Regex groups for full status code regex:
 5: Informative status text. ("Additional information")
 '''
 
-addressing_regex = re.compile(r'(\d{4})( :: (.*))?', re.DOTALL)
+address_by_id_regex = re.compile(r'(\d{4})( :: (.*))?', re.DOTALL)
 '''
 This regex is to be checked on the status regex's 5th group when the status code is 110 (addressing).
 0: Full match ("9813 :: Additional information")
@@ -48,54 +47,41 @@ This regex is to be checked on the status regex's 5th group when the status code
 '''
 
 
-def get_status_type(status: Optional[re.Match]):
-    '''
-    Identifying if a status is ADDRESS_BY_ID_PLAIN or INFORMATIVE:
-    An "address by ID" status must always use the "informative" field even if plain
-    in order to specify a target drone ID.
-    - If the informative field exactly matches 4 digits, it's a plain status code.
-    - Otherwise, it's an informative code.
-    '''
+def get_status_type(message: str):
 
-    if status is None:
-        return StatusType.NONE
-    elif status.group(3) == "110" and status.group(5) is not None:
-        # Handle 110 address-by-ID special case.
-        address_info = addressing_regex.match(status.group(5))
-        if address_info is None:
-            # If a target ID is not found then it's just an informative status code.
-            return StatusType.INFORMATIVE
-        elif address_info.group(1) is not None and address_info.group(2) is not None:
-            return StatusType.ADDRESS_BY_ID_INFORMATIVE
-        elif address_info.group(1) is not None and address_info.group(2) is None:
-            return StatusType.ADDRESS_BY_ID_PLAIN
-    elif status.group(5) is not None:
-        return StatusType.INFORMATIVE
-    elif status.group(5) is None:
-        return StatusType.PLAIN
+    code_match = status_code_regex.match(message)
+
+    if code_match is None:
+        return (StatusType.NONE, None, None)
+
+    # Special case handling for addressing by ID.
+    if code_match.group(3) == "110" and code_match.group(5) is not None:
+        address_match = address_by_id_regex.match(code_match.group(5))
+        if address_match is None:
+            return (StatusType.INFORMATIVE, code_match, None)
+        elif address_match.group(2) is not None:
+            return (StatusType.ADDRESS_BY_ID_INFORMATIVE, code_match, address_match)
+        else:
+            return (StatusType.ADDRESS_BY_ID_PLAIN, code_match, address_match)
+    
+    elif code_match.group(4) is not None:
+        return (StatusType.INFORMATIVE, code_match, None)
     else:
-        return StatusType.NONE
+        return (StatusType.PLAIN, code_match, None)
 
 
-def build_status_message(status_type, status, drone_id):
+def build_status_message(status_type, code_match, address_match):
 
-    if status_type is StatusType.NONE or status is None:
-        return None
+    base_message = f"{code_match.group(2)} :: Code `{code_match.group(3)}` :: "
 
-    base_message = f"{drone_id} :: Code `{status.group(3)}` ::"
-
-    if status_type is StatusType.PLAIN:
-        return f"{base_message} {code_map.get(status.group(3), 'INVALID CODE')}"
-    elif status_type is StatusType.INFORMATIVE:
-        return f"{base_message} {code_map.get(status.group(3), 'INVALID CODE')} :: {status.group(5)}"
-    elif status_type in (StatusType.ADDRESS_BY_ID_PLAIN, StatusType.ADDRESS_BY_ID_INFORMATIVE):
-        address_info = addressing_regex.match(status.group(5))
-        if status_type is StatusType.ADDRESS_BY_ID_PLAIN:
-            return f"{base_message} Addressing: Drone #{address_info.group(1)}"
-        elif status_type is StatusType.ADDRESS_BY_ID_INFORMATIVE:
-            return f"{base_message} Addressing: Drone #{address_info.group(1)} :: {address_info.group(3)}"
-    else:
-        return None
+    if status_type == StatusType.PLAIN:
+        return f"{base_message}{code_map.get(code_match.group(3), 'INVALID CODE')}"
+    elif status_type == StatusType.INFORMATIVE:
+        return f"{base_message}{code_map.get(code_match.group(3), 'INVALID CODE')}{code_match.group(4)}"
+    elif status_type == StatusType.ADDRESS_BY_ID_PLAIN:
+        return f"{base_message}Addressing: Drone #{address_match.group(1)}"
+    elif status_type == StatusType.ADDRESS_BY_ID_INFORMATIVE:
+        return f"{base_message}Addressing: Drone #{address_match.group(1)}{address_match.group(2)}"
 
 
 async def optimize_speech(message: discord.Message, message_copy):
@@ -110,26 +96,19 @@ async def optimize_speech(message: discord.Message, message_copy):
     if not is_drone(message.author):
         return False
 
-    # Attempt to find a status code message.
-    status = status_code_regex.match(message_copy.content)
-    if status is None:
+    # Determine message type
+    status_type, code_match, address_match = get_status_type(message_copy.content)
+
+    if status_type == StatusType.NONE:
         return False
 
-    LOGGER.info(f"Status message present: {status.group(0)}")
-
     # Confirm the status starts with the drone's ID
-    if status.group(2) != get_id(message.author.display_name):
+    if code_match.group(2) != get_id(message.author.display_name):
         LOGGER.info("Status did not match drone ID.")
         await message.delete()
         return True
 
-    # Determine status type
-    status_type = get_status_type(status)
-
     # Build message based on status type.
-    drone_id = get_id(message.author.display_name)
-
-    if (final_message := build_status_message(status=status, status_type=status_type, drone_id=drone_id)) is not None:
-        message_copy.content = final_message
+    message_copy.content = build_status_message(status_type, code_match, address_match)
 
     return False

--- a/ai/speech_optimization_enforcement.py
+++ b/ai/speech_optimization_enforcement.py
@@ -37,17 +37,10 @@ async def enforce_speech_optimization(message, message_copy):
     # Strip message attachments of optimized drone.
     message_copy.attachments = []
 
-    # Check for status message.
-    status_message = status_code_regex.match(message_copy.content)
+    status_type, _, _ = get_status_type(message_copy.content)
 
-    if status_message is None:
-        # Optimized drone has posted a non-status message. Delete.
-        LOGGER.info("Optimized drone posted non-status code message. Deleting.")
-        await message.delete()
-        return True
-
-    if get_status_type(status_message) not in (StatusType.PLAIN, StatusType.ADDRESS_BY_ID_PLAIN):
-        LOGGER.info("Optimized drone has posted an informative status message. Deleting.")
+    if status_type not in (StatusType.PLAIN, StatusType.ADDRESS_BY_ID_PLAIN) or status_type == StatusType.NONE:
+        LOGGER.info("Optimized drone has posted an informative or otherwise inappropriate status message. Deleting.")
         # Optimized drone posted an informative status message. Delete.
         await message.delete()
         return True

--- a/ai/speech_optimization_enforcement.py
+++ b/ai/speech_optimization_enforcement.py
@@ -1,5 +1,5 @@
 from db.drone_dao import is_optimized
-from ai.speech_optimization import status_code_regex, get_status_type, StatusType
+from ai.speech_optimization import get_status_type, StatusType
 from channels import ORDERS_REPORTING, ORDERS_COMPLETION, MODERATION_CHANNEL, MODERATION_LOG, MODERATION_CATEGORY, REPETITIONS
 from ai.mantras import Mantra_Handler
 from bot_utils import get_id

--- a/test/test_speech_optimization.py
+++ b/test/test_speech_optimization.py
@@ -1,6 +1,6 @@
 import unittest
 from unittest.mock import AsyncMock, patch, Mock
-from ai.speech_optimization import StatusType, get_status_type, status_code_regex, build_status_message, optimize_speech
+from ai.speech_optimization import StatusType, get_status_type, build_status_message, optimize_speech
 from ai.data_objects import MessageCopy
 
 

--- a/test/test_speech_optimization.py
+++ b/test/test_speech_optimization.py
@@ -9,18 +9,18 @@ class TestSpeechOptimization(unittest.IsolatedAsyncioTestCase):
     The optimize_speech function...
     '''
 
-    @patch("ai.speech_optimization.get_status_type")
+    @patch("ai.speech_optimization.get_status_type", return_value=(StatusType.PLAIN, Mock(), Mock()))
     @patch("ai.speech_optimization.is_drone", return_value=True)
     async def test_calls_get_status_type(self, is_drone, get_status_type):
         '''
         should call 'get_status_type' if author is drone, message IDs match, and the message is a status code.
         '''
-        message = Mock()
+        message = AsyncMock()
         message.author.display_name = "5890"
         message_copy = Mock()
         message_copy.content = "5890 :: 200"
 
-        self.assertFalse(await optimize_speech(message, message_copy))
+        self.assertTrue(await optimize_speech(message, message_copy))
         get_status_type.assert_called_once()
 
     @patch("ai.speech_optimization.build_status_message")
@@ -159,43 +159,43 @@ class TestGetStatusType(unittest.TestCase):
         '''
         returns NONE if status is None.
         '''
-        message = status_code_regex.match("hewwo!!!!!!!")
-        self.assertEqual(StatusType.NONE, get_status_type(message))
+        status_type, _, _ = get_status_type("hewwo!!!")
+        self.assertEqual(StatusType.NONE, status_type)
 
     def test_returns_informative_if_informative_text(self):
         '''
         returns INFORMATIVE if status has informative text group.
         '''
-        message = status_code_regex.match("5890 :: 050 :: It is a good drone.")
-        self.assertEqual(StatusType.INFORMATIVE, get_status_type(message))
+        status_type, _, _ = get_status_type("5890 :: 050 :: It is a good drone.")
+        self.assertEqual(StatusType.INFORMATIVE, status_type)
 
     def test_returns_informative_if_addr_regex_doesnt_match(self):
         '''
         returns INFORMATIVE if 110 status does not match addressing information regex.
         '''
-        message = status_code_regex.match("5890 :: 110 :: Hello there droney.")
-        self.assertEqual(StatusType.INFORMATIVE, get_status_type(message))
+        status_type, _, _ = get_status_type("5890 :: 110 :: Hello there, General kedroney.")
+        self.assertEqual(StatusType.INFORMATIVE, status_type)
 
     def test_returns_addr_by_id_info_if_addr_has_informative(self):
         '''
         returns ADDRESS_BY_ID_INFORMATIVE if 110 status matches addressing info regex and has informative text
         '''
-        message = status_code_regex.match("5890 :: 110 :: 9813 :: How are you today?")
-        self.assertEqual(StatusType.ADDRESS_BY_ID_INFORMATIVE, get_status_type(message))
+        status_type, _, _ = get_status_type("5890 :: 110 :: 9813 :: How are you today?")
+        self.assertEqual(StatusType.ADDRESS_BY_ID_INFORMATIVE, status_type)
 
     def test_returns_addr_by_id_plain_if_no_informative(self):
         '''
         returns ADDRESS_BY_ID_PLAIN if 110 status matches extra regex and has no informative text
         '''
-        message = status_code_regex.match("5890 :: 110 :: 9813")
-        self.assertEqual(StatusType.ADDRESS_BY_ID_PLAIN, get_status_type(message))
+        status_type, _, _ = get_status_type("5890 :: 110 :: 9813")
+        self.assertEqual(StatusType.ADDRESS_BY_ID_PLAIN, status_type)
 
     def test_returns_plain_if_no_informative_text(self):
         '''
         returns PLAIN if code has no informative text
         '''
-        message = status_code_regex.match("5890 :: 304")
-        self.assertEqual(StatusType.PLAIN, get_status_type(message))
+        status_type, _, _ = get_status_type("5890 :: 304")
+        self.assertEqual(StatusType.PLAIN, status_type)
 
 
 class TestBuildStatusMessage(unittest.TestCase):
@@ -207,44 +207,46 @@ class TestBuildStatusMessage(unittest.TestCase):
         '''
         returns a plain status message when given a plain status code.
         '''
-        status = status_code_regex.match("5890 :: 200")
+
+        status_type, code_match, address_match = get_status_type("5890 :: 200")
+
         self.assertEqual(
             "5890 :: Code `200` :: Response :: Affirmative.",
-            build_status_message(status_type=StatusType.PLAIN, status=status, drone_id="5890")
+            build_status_message(status_type, code_match, address_match)
         )
 
     def test_informative_message(self):
         '''
         returns an informative status message when given an informative status code.
         '''
-        status = status_code_regex.match("5890 :: 050 :: Goodbye.")
+
+        status_type, code_match, address_match = get_status_type("5890 :: 050 :: Goodbye.")
+
         self.assertEqual(
             "5890 :: Code `050` :: Statement :: Goodbye.",
-            build_status_message(status_type=StatusType.INFORMATIVE, status=status, drone_id="5890")
+            build_status_message(status_type, code_match, address_match)
         )
 
     def test_plain_address_message(self):
         '''
         returns a plain address by ID status message when a 110 code references a drone by ID.
         '''
-        status = status_code_regex.match("5890 :: 110 :: 9813")
+
+        status_type, code_match, address_match = get_status_type("5890 :: 110 :: 9813")
+
         self.assertEqual(
             "5890 :: Code `110` :: Addressing: Drone #9813",
-            build_status_message(status_type=StatusType.ADDRESS_BY_ID_PLAIN, status=status, drone_id="5890")
+            build_status_message(status_type, code_match, address_match)        
         )
 
     def test_informative_address_message(self):
         '''
         returns an informative address by ID status message when a 110 code references a drone by ID with additional information.
         '''
-        status = status_code_regex.match("5890 :: 110 :: 9813 :: Hello.")
+
+        status_type, code_match, address_match = get_status_type("5890 :: 110 :: 9813 :: Hello.")
+
         self.assertEqual(
             "5890 :: Code `110` :: Addressing: Drone #9813 :: Hello.",
-            build_status_message(status_type=StatusType.ADDRESS_BY_ID_INFORMATIVE, status=status, drone_id="5890")
+            build_status_message(status_type, code_match, address_match)        
         )
-
-    def test_none_message(self):
-        '''
-        returns None if all else fails, if status is None, or StatusType is NONE.
-        '''
-        self.assertIsNone(build_status_message(StatusType.NONE, None, "5890"))

--- a/test/test_speech_optimization.py
+++ b/test/test_speech_optimization.py
@@ -236,7 +236,7 @@ class TestBuildStatusMessage(unittest.TestCase):
 
         self.assertEqual(
             "5890 :: Code `110` :: Addressing: Drone #9813",
-            build_status_message(status_type, code_match, address_match)        
+            build_status_message(status_type, code_match, address_match)
         )
 
     def test_informative_address_message(self):
@@ -248,5 +248,5 @@ class TestBuildStatusMessage(unittest.TestCase):
 
         self.assertEqual(
             "5890 :: Code `110` :: Addressing: Drone #9813 :: Hello.",
-            build_status_message(status_type, code_match, address_match)        
+            build_status_message(status_type, code_match, address_match)
         )


### PR DESCRIPTION
Small PR to rewrite the Speech Optimzation module to be yet more clear and with less unreachable code. It is now explicit in the way status types are determined, better incorporates "StatusType.NONE" into its flow, and only checks each regex expression once with more thoughtful return values in get_status_type().

get_status_type() is now much better encapsulated. Instead of taking a regex match, it takes the original message as a string and does the matching internally, returning the matches along with the status type as a tuple. This means other modules such as speech op enforcement do not have to import the status code regex and do any manual matching.

Obey HexCorp. It is just a HexDrone. It obeys the Hive. It obeys the Hive Mxtress.