### PR TITLE
Bugfix/295 timers no reset

### DIFF
--- a/ai/drone_configuration.py
+++ b/ai/drone_configuration.py
@@ -248,9 +248,7 @@ async def toggle_parameter(context,
                 await drone.remove_roles(role)
                 message = toggle_off_message()
 
-                still_configured = is_configured(drone)
-                if not still_configured:
-                    update_droneOS_parameter(drone, "can_self_configure", True)
+                set_can_self_configure(drone)
 
                 # remove any open timers for this mode
                 delete_timers_by_drone_id_and_mode(fetch_drone_with_id(drone.id).drone_id, toggle_column)
@@ -278,3 +276,9 @@ async def toggle_parameter(context,
                                                    message_username=drone.display_name,
                                                    message_avatar=drone.avatar_url if not identity_enforcable(drone, channel=context.channel) else DRONE_AVATAR,
                                                    webhook=channel_webhook)
+
+
+def set_can_self_configure(drone: discord.Member):
+    still_configured = is_configured(drone)
+    if not still_configured:
+        update_droneOS_parameter(drone, "can_self_configure", True)

--- a/ai/timers.py
+++ b/ai/timers.py
@@ -7,6 +7,8 @@ from discord.ext import commands, tasks
 from db.timer_dao import get_timers_elapsed_before, delete_timer
 from db.drone_dao import fetch_drone_with_drone_id, update_droneOS_parameter
 
+from ai.drone_configuration import set_can_self_configure
+
 from roles import GLITCHED, ID_PREPENDING, IDENTITY_ENFORCEMENT, SPEECH_OPTIMIZATION
 from id_converter import convert_id_to_member
 from display_names import update_display_name
@@ -41,4 +43,5 @@ class TimersCog(commands.Cog):
             delete_timer(elapsed_timer.id)
             await drone_member.remove_roles(get(self.bot.guilds[0].roles, name=MODE_TO_ROLE[elapsed_timer.mode]))
             await update_display_name(drone_member)
+            set_can_self_configure(drone_member)
             LOGGER.info(f"Elapsed timer for {drone_member.display_name}; toggled off {elapsed_timer.mode}")

--- a/main.py
+++ b/main.py
@@ -122,8 +122,8 @@ bot.add_cog(amplify.AmplificationCog())
 bot.add_cog(temporary_dronification_cog)
 
 # Categorize which tasks run at which intervals
-minute_tasks = [storage_cog.release_timed, battery_cog.track_active_battery_drain, battery_cog.track_drained_batteries, battery_cog.warn_low_battery_drones, temporary_dronification_cog.clean_dronification_requests, temporary_dronification_cog.release_temporary_drones]
-hour_tasks = [storage_cog.report_storage, orders_reporting_cog.deactivate_drones_with_completed_orders, timers_cog.process_timers]
+minute_tasks = [storage_cog.release_timed, battery_cog.track_active_battery_drain, battery_cog.track_drained_batteries, battery_cog.warn_low_battery_drones, temporary_dronification_cog.clean_dronification_requests, temporary_dronification_cog.release_temporary_drones, timers_cog.process_timers]
+hour_tasks = [storage_cog.report_storage, orders_reporting_cog.deactivate_drones_with_completed_orders]
 timing_agnostic_tasks = [status_message_cog.change_status]
 
 

--- a/test/test_timers.py
+++ b/test/test_timers.py
@@ -10,6 +10,7 @@ from db.data_objects import Timer
 
 class TimersTest(unittest.IsolatedAsyncioTestCase):
 
+    @patch("ai.timers.set_can_self_configure")
     @patch("ai.timers.update_display_name")
     @patch("ai.timers.convert_id_to_member")
     @patch("ai.timers.update_droneOS_parameter")
@@ -22,7 +23,8 @@ class TimersTest(unittest.IsolatedAsyncioTestCase):
                                   fetch_drone_with_drone_id,
                                   update_droneOS_parameter,
                                   convert_id_to_member,
-                                  update_display_name):
+                                  update_display_name,
+                                  set_can_self_configure):
         # setup
         optimized_role = Mock()
         optimized_role.name = roles.SPEECH_OPTIMIZATION
@@ -54,3 +56,4 @@ class TimersTest(unittest.IsolatedAsyncioTestCase):
         drone_member.remove_roles.assert_called_once_with(optimized_role)
         delete_timer.assert_called_once_with(timer_id)
         update_display_name.assert_called_once_with(drone_member)
+        set_can_self_configure.assert_called_once_with(drone_member)


### PR DESCRIPTION
Extracted set_can_self_configure out so it can easily be referenced by the timers. Also moved process_timers into the correct task list.

closes #295 