### PR TITLE
emergency release removes battery_powered

### DIFF
--- a/ai/drone_configuration.py
+++ b/ai/drone_configuration.py
@@ -201,7 +201,8 @@ async def emergency_release(context, drone_id: str):
     update_droneOS_parameter(drone_member, "optimized", False)
     update_droneOS_parameter(drone_member, "identity_enforcement", False)
     update_droneOS_parameter(drone_member, "glitched", False)
-    await drone_member.remove_roles(get(context.guild.roles, name=SPEECH_OPTIMIZATION), get(context.guild.roles, name=GLITCHED), get(context.guild.roles, name=ID_PREPENDING), get(context.guild.roles, name=IDENTITY_ENFORCEMENT))
+    update_droneOS_parameter(drone_member, "is_battery_powered", False)
+    await drone_member.remove_roles(get(context.guild.roles, name=SPEECH_OPTIMIZATION), get(context.guild.roles, name=GLITCHED), get(context.guild.roles, name=ID_PREPENDING), get(context.guild.roles, name=IDENTITY_ENFORCEMENT), get(context.guild.roles, name=BATTERY_DRAINED))
     await update_display_name(drone_member)
 
     await context.channel.send(f"Restrictions disabled for drone {drone_id}.")


### PR DESCRIPTION
Just required to add the config to the `emergency_release` function

closes #284 