### PR TITLE
change API to pycord

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-discord.py ~= 1.6.0
+py-cord ~= 1.7.3
 glitch-this ~= 1.0.2

--- a/test/test_battery.py
+++ b/test/test_battery.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import AsyncMock, patch, Mock
 import ai.battery as battery
 import emoji
+import test.test_utils as test_utils
 
 
 class TestBattery(unittest.IsolatedAsyncioTestCase):
@@ -51,9 +52,7 @@ class TestBattery(unittest.IsolatedAsyncioTestCase):
 
         battery_cog.draining_batteries = {'5890': 10}
 
-        battery_cog.track_active_battery_drain.start()
-        battery_cog.track_active_battery_drain.stop()
-        await battery_cog.track_active_battery_drain.get_task()
+        await test_utils.start_and_await_loop(battery_cog.track_active_battery_drain)
 
         deincrement.assert_called_once()
         self.assertEqual(battery_cog.draining_batteries.get('5890', None), 9)
@@ -70,9 +69,7 @@ class TestBattery(unittest.IsolatedAsyncioTestCase):
 
         battery_cog.draining_batteries = {'9813': 0}
 
-        battery_cog.track_active_battery_drain.start()
-        battery_cog.track_active_battery_drain.stop()
-        await battery_cog.track_active_battery_drain.get_task()
+        await test_utils.start_and_await_loop(battery_cog.track_active_battery_drain)
 
         self.assertIsNone(battery_cog.draining_batteries.get('9813', None))
 
@@ -101,9 +98,7 @@ class TestBattery(unittest.IsolatedAsyncioTestCase):
 
         battery_cog = battery.BatteryCog(bot)
 
-        battery_cog.track_drained_batteries.start()
-        battery_cog.track_drained_batteries.stop()
-        await battery_cog.track_drained_batteries.get_task()
+        await test_utils.start_and_await_loop(battery_cog.track_drained_batteries)
 
         member.add_roles.assert_called_once_with(drained_role)
 
@@ -132,9 +127,7 @@ class TestBattery(unittest.IsolatedAsyncioTestCase):
 
         battery_cog = battery.BatteryCog(bot)
 
-        battery_cog.track_drained_batteries.start()
-        battery_cog.track_drained_batteries.stop()
-        await battery_cog.track_drained_batteries.get_task()
+        await test_utils.start_and_await_loop(battery_cog.track_drained_batteries)
 
         member.remove_roles.assert_called_once_with(drained_role)
 
@@ -158,9 +151,7 @@ class TestBattery(unittest.IsolatedAsyncioTestCase):
 
         battery_cog = battery.BatteryCog(bot)
 
-        battery_cog.warn_low_battery_drones.start()
-        battery_cog.warn_low_battery_drones.stop()
-        await battery_cog.warn_low_battery_drones.get_task()
+        await test_utils.start_and_await_loop(battery_cog.warn_low_battery_drones)
 
         member.send.assert_called_once_with("Attention. Your battery is low (30%). Please connect to main power grid in the Storage Facility immediately.")
         self.assertTrue('5890' in battery_cog.low_battery_drones)
@@ -187,9 +178,7 @@ class TestBattery(unittest.IsolatedAsyncioTestCase):
         battery_cog = battery.BatteryCog(bot)
         battery_cog.low_battery_drones = ['5890']
 
-        battery_cog.warn_low_battery_drones.start()
-        battery_cog.warn_low_battery_drones.stop()
-        await battery_cog.warn_low_battery_drones.get_task()
+        await test_utils.start_and_await_loop(battery_cog.warn_low_battery_drones)
 
         member.send.assert_not_called()
 
@@ -214,9 +203,7 @@ class TestBattery(unittest.IsolatedAsyncioTestCase):
         battery_cog = battery.BatteryCog(bot)
         battery_cog.low_battery_drones = ['5890']
 
-        battery_cog.warn_low_battery_drones.start()
-        battery_cog.warn_low_battery_drones.stop()
-        await battery_cog.warn_low_battery_drones.get_task()
+        await test_utils.start_and_await_loop(battery_cog.warn_low_battery_drones)
 
         member.send.assert_not_called()
         self.assertTrue('5890' not in battery_cog.low_battery_drones)

--- a/test/test_orders_reporting.py
+++ b/test/test_orders_reporting.py
@@ -7,6 +7,7 @@ import roles
 import channels
 import ai.orders_reporting as orders_reporting
 from db.data_objects import DroneOrder
+import test.test_utils as test_utils
 
 drone_role = Mock()
 drone_role.name = roles.DRONE
@@ -42,9 +43,7 @@ class OrdersReportingTest(unittest.IsolatedAsyncioTestCase):
         orders_reporting_cog = orders_reporting.OrderReportingCog(bot)
 
         # run
-        orders_reporting_cog.deactivate_drones_with_completed_orders.start()
-        orders_reporting_cog.deactivate_drones_with_completed_orders.stop()
-        await orders_reporting_cog.deactivate_drones_with_completed_orders.get_task()
+        await test_utils.start_and_await_loop(orders_reporting_cog.deactivate_drones_with_completed_orders)
 
         # assert
         convert_id_to_member.assert_called_once_with(bot.guilds[0], '5890')
@@ -57,9 +56,7 @@ class OrdersReportingTest(unittest.IsolatedAsyncioTestCase):
         orders_reporting_cog = orders_reporting.OrderReportingCog(bot)
 
         # run
-        orders_reporting_cog.deactivate_drones_with_completed_orders.start()
-        orders_reporting_cog.deactivate_drones_with_completed_orders.stop()
-        await orders_reporting_cog.deactivate_drones_with_completed_orders.get_task()
+        await test_utils.start_and_await_loop(orders_reporting_cog.deactivate_drones_with_completed_orders)
 
         # assert
         orders_reporting_channel.send.assert_not_called()

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -7,6 +7,7 @@ import roles
 import channels
 import ai.storage as storage
 from db.data_objects import Storage, Drone
+import test.test_utils as test_utils
 
 storage_channel = AsyncMock()
 
@@ -209,27 +210,27 @@ class StorageTest(unittest.IsolatedAsyncioTestCase):
     @patch("ai.storage.fetch_all_storage", return_value=[])
     async def test_storage_report_empty(self, fetch_all_storage):
         storage_cog = storage.StorageCog(bot)
-        storage_cog.report_storage.start()
-        storage_cog.report_storage.stop()
-        await storage_cog.report_storage.get_task()
+
+        await test_utils.start_and_await_loop(storage_cog.report_storage)
+
         storage_cog.storage_channel.send.assert_called_once_with('No drones in storage.')
 
     @patch("ai.storage.recharge_battery")
     @patch("ai.storage.fetch_all_storage", return_value=[Storage(str(uuid4()), '9813', '3287', 'trying to break the AI', '', str(datetime.now() + timedelta(hours=4)))])
     async def test_storage_report(self, fetch_all_storage, recharge):
         storage_cog = storage.StorageCog(bot)
-        storage_cog.report_storage.start()
-        storage_cog.report_storage.stop()
-        await storage_cog.report_storage.get_task()
+
+        await test_utils.start_and_await_loop(storage_cog.report_storage)
+
         storage_cog.storage_channel.send.assert_called_once_with('`Drone #3287`, stored away by `Drone #9813`. Remaining time in storage: 4.0 hours')
 
     @patch("ai.storage.recharge_battery")
     @patch("ai.storage.fetch_all_storage", return_value=[Storage(str(uuid4()), '0006', '3287', 'trying to break the AI', '', str(datetime.now() + timedelta(hours=4)))])
     async def test_storage_report_hive_mxtress(self, fetch_all_storage, recharge_battery):
         storage_cog = storage.StorageCog(bot)
-        storage_cog.report_storage.start()
-        storage_cog.report_storage.stop()
-        await storage_cog.report_storage.get_task()
+
+        await test_utils.start_and_await_loop(storage_cog.report_storage)
+
         storage_cog.storage_channel.send.assert_called_once_with('`Drone #3287`, stored away by the Hive Mxtress. Remaining time in storage: 4.0 hours')
 
     @patch("ai.storage.delete_storage")
@@ -242,9 +243,7 @@ class StorageTest(unittest.IsolatedAsyncioTestCase):
         storage_cog = storage.StorageCog(bot)
 
         # run
-        storage_cog.release_timed.start()
-        storage_cog.release_timed.stop()
-        await storage_cog.release_timed.get_task()
+        await test_utils.start_and_await_loop(storage_cog.release_timed)
 
         # assert
         bot.guilds[0].get_member.assert_called_once_with('3287snowflake')

--- a/test/test_timers.py
+++ b/test/test_timers.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 import roles
 from ai.timers import TimersCog
 from db.data_objects import Timer
+import test.test_utils as test_utils
 
 
 class TimersTest(unittest.IsolatedAsyncioTestCase):
@@ -47,9 +48,7 @@ class TimersTest(unittest.IsolatedAsyncioTestCase):
         fetch_drone_with_drone_id.return_value = drone
 
         # run
-        timer_cog.process_timers.start()
-        timer_cog.process_timers.stop()
-        await timer_cog.process_timers.get_task()
+        await test_utils.start_and_await_loop(timer_cog.process_timers)
 
         # assert
         convert_id_to_member.assert_called_once_with(bot.guilds[0], timer.drone_id)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,12 @@
+from discord.ext.tasks import Loop
+
+
+async def start_and_await_loop(loop: Loop):
+    '''
+    Changes the interval time for the given loop to 1 second, starts the loop,
+    stops it immediately and then waits until the one scheduled execution has terminated.
+    '''
+    loop.change_interval(seconds=1, minutes=0, hours=0)
+    loop.start()
+    loop.stop()
+    await loop.get_task()


### PR DESCRIPTION
Nothing really changed in the API but I had to change the way we test loops a bit as they actually blocked for the configured time. There is now a new utility function that sets the loop interval to 1 second and then runs the loop. This reduces the wait time to an acceptable level.