### PR TITLE
hyperlinks and spoilers are now protected from glitching

### DIFF
--- a/ai/glitch_message.py
+++ b/ai/glitch_message.py
@@ -24,7 +24,7 @@ glitcher = glitch_this.ImageGlitcher()
 
 LOGGER = logging.getLogger('ai')
 
-protected_text_regex = re.compile(r'(<:(.*?):\d{18}>)|(\|\|.*\|\|)|((?:https?)://\S+)')
+protected_text_regex = re.compile(r'(<:(.*?):\d{18}>)|(\|\|.*\|\|)|(https?://\S+)')
 
 
 def escape_characters(message: str, characters_regex):

--- a/ai/glitch_message.py
+++ b/ai/glitch_message.py
@@ -24,7 +24,20 @@ glitcher = glitch_this.ImageGlitcher()
 
 LOGGER = logging.getLogger('ai')
 
-custom_emoji_regex = re.compile(r'<:(.*?):\d{18}>')
+protected_text_regex = re.compile(r'(<:(.*?):\d{18}>)|(\|\|.*\|\|)|((?:https?)://\S+)')
+
+
+def escape_characters(message: str, characters_regex):
+    escaped_characters = []
+    modified_message = message
+
+    for custom_emoji in re.finditer(characters_regex, message):
+        LOGGER.debug(f"Custom emoji found at position {custom_emoji.start()}: {custom_emoji}")
+        escaped_characters.append((custom_emoji.group(), max(0, custom_emoji.start())))
+        modified_message = re.sub(pattern=characters_regex, repl='', string=modified_message, count=1)
+        LOGGER.debug(f"Custom emoji removed. Current message: {message}")
+
+    return escaped_characters, modified_message
 
 
 def glitch_text(message: str, glitch_amount=45) -> str:
@@ -37,16 +50,10 @@ def glitch_text(message: str, glitch_amount=45) -> str:
 
     message_length_with_emoji: int = len(message)
 
-    custom_emojis = []
+    # Temporarily remove custom emojis, spoilered text and hyperlinks
+    escaped_characters, modified_message = escape_characters(message, protected_text_regex)
 
-    # Temporarily remove custom emojis
-    for custom_emoji in re.finditer(custom_emoji_regex, message):
-        LOGGER.debug(f"Custom emoji found at position {custom_emoji.start()}: {custom_emoji}")
-        custom_emojis.append((custom_emoji.group(), max(0, custom_emoji.start())))
-        message = re.sub(pattern=custom_emoji_regex, repl='', string=message, count=1)
-        LOGGER.debug(f"Custom emoji removed. Current message: {message}")
-
-    message_list = list(message)
+    message_list = list(modified_message)
 
     message_length_without_emoji: int = len(message_list)
 
@@ -57,7 +64,7 @@ def glitch_text(message: str, glitch_amount=45) -> str:
 
     if message_list == []:
         LOGGER.info("Not glitching message (message empty).")
-        return ''.join(emoji for emoji, index in custom_emojis)
+        return ''.join(emoji for emoji, index in escaped_characters)
 
     # Flip case
     for i in range(0, math.ceil(len(message_list) * glitch_percentage)):
@@ -71,7 +78,7 @@ def glitch_text(message: str, glitch_amount=45) -> str:
             LOGGER.warn(f"Index error. Length of list: {len(message_list)} Index: {index}")
 
     # Add diacritics
-    max_characters_to_glitch = min(math.ceil(len(message) * glitch_percentage), MAX_DIACRITICS_PER_MESSAGE)
+    max_characters_to_glitch = min(math.ceil(len(modified_message) * glitch_percentage), MAX_DIACRITICS_PER_MESSAGE)
     LOGGER.debug(f"Adding diacritics to {max_characters_to_glitch} characters.")
     for i in range(0, min(int(max_characters_to_glitch), DISCORD_CHAR_LIMIT - message_length_with_emoji)):
         if added_diacritics + message_length_with_emoji >= DISCORD_CHAR_LIMIT:
@@ -82,7 +89,7 @@ def glitch_text(message: str, glitch_amount=45) -> str:
             added_diacritics += 1
 
     # Add custom emojis back in
-    for custom_emoji, reinsertion_index in custom_emojis:
+    for custom_emoji, reinsertion_index in escaped_characters:
         try:
             message_list[reinsertion_index:reinsertion_index] = list(custom_emoji)
         except IndexError:

--- a/test/test_glitch_message.py
+++ b/test/test_glitch_message.py
@@ -1,0 +1,55 @@
+import unittest
+from ai.glitch_message import escape_characters, protected_text_regex
+
+
+class GlitchMessageTest(unittest.TestCase):
+
+    def test_escape_custom_emoji(self):
+        # init
+        message = "abcd <:custom_emoji:123456789012345678> hgjgjh"
+
+        # run
+        _, modified_message = escape_characters(message, protected_text_regex)
+
+        # assert
+        self.assertEqual(modified_message, "abcd  hgjgjh")
+
+    def test_escape_spoiler(self):
+        # init
+        message = "abcd||this should not be glitched||hgjgjh"
+
+        # run
+        _, modified_message = escape_characters(message, protected_text_regex)
+
+        # assert
+        self.assertEqual(modified_message, "abcdhgjgjh")
+
+    def test_escape_hyperlinks(self):
+        # init
+        message = "abcd https://www.hexcorp.net hgjgjh"
+
+        # run
+        _, modified_message = escape_characters(message, protected_text_regex)
+
+        # assert
+        self.assertEqual(modified_message, "abcd  hgjgjh")
+
+    def test_escape_nothing(self):
+        # init
+        message = "abcd  hgjgjh"
+
+        # run
+        _, modified_message = escape_characters(message, protected_text_regex)
+
+        # assert
+        self.assertEqual(modified_message, "abcd  hgjgjh")
+
+    def test_escape_all(self):
+        # init
+        message = "beep <:custom_emoji:123456789012345678> boop https://www.hexcorp.net beep ||this should not be glitched|| boop"
+
+        # run
+        _, modified_message = escape_characters(message, protected_text_regex)
+
+        # assert
+        self.assertEqual(modified_message, "beep  boop  beep  boop")


### PR DESCRIPTION
I extracted the escaping logic out to make it easily testable and extended the regex that protects custom emojis to also cover spoilers and hyperlinks. The regex for links is pretty basic, but should do it for most cases.

closes #315 