### PR TITLE
release command is now usable by all moderators

### DIFF
--- a/ai/storage.py
+++ b/ai/storage.py
@@ -46,8 +46,7 @@ class StorageCog(Cog):
         '''
         Allows the Hive Mxtress to release a drone from storage.
         '''
-        if roles.has_role(context.author, roles.HIVE_MXTRESS):
-            await release(context, drone)
+        await release(context, drone)
 
     @tasks.loop(hours=1)
     async def report_storage(self):
@@ -105,7 +104,7 @@ async def store_drone(message: discord.Message, message_copy=None):
 
     # parse message
     if not re.match(MESSAGE_FORMAT, message.content):
-        if roles.has_role(message.author, roles.HIVE_MXTRESS):
+        if roles.has_any_role(message.author, roles.MODERATION_ROLES):
             return False
         await message.channel.send(REJECT_MESSAGE)
         return True
@@ -164,7 +163,7 @@ async def release(context, stored_drone):
     '''
     Relase a drone from storage on command.
     '''
-    if not roles.has_role(context.author, roles.HIVE_MXTRESS) or context.channel.name != STORAGE_FACILITY:
+    if not roles.has_any_role(context.author, roles.MODERATION_ROLES) or context.channel.name != STORAGE_FACILITY:
         return False
 
     if type(store_drone) is not discord.Member:
@@ -183,7 +182,7 @@ async def release(context, stored_drone):
         delete_storage(stored_drone_data.id)
         LOGGER.debug(
             f"Drone with ID {release_id} released from storage.")
-        await context.send(f"{stored_drone.display_name} has been released from storage by the Hive Mxtress.")
+        await context.send(f"{stored_drone.display_name} has been released from storage.")
     return True
 
 

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -252,7 +252,7 @@ class StorageTest(unittest.IsolatedAsyncioTestCase):
         delete_storage.assert_called_once_with('elapse_storage_id')
 
     async def test_release_unauthorized(self):
-        for role in [roles.INITIATE, roles.ASSOCIATE, roles.DRONE, roles.STORED, roles.DEVELOPMENT, roles.ADMIN, roles.MODERATION, roles.SPEECH_OPTIMIZATION, roles.GLITCHED, roles.NITRO_BOOSTER]:
+        for role in [roles.INITIATE, roles.ASSOCIATE, roles.DRONE, roles.STORED, roles.DEVELOPMENT, roles.SPEECH_OPTIMIZATION, roles.GLITCHED, roles.NITRO_BOOSTER]:
             # setup
             role_mock = Mock()
             role_mock.name = role
@@ -279,22 +279,30 @@ class StorageTest(unittest.IsolatedAsyncioTestCase):
     @patch("ai.storage.convert_id_to_member")
     @patch("ai.storage.delete_storage")
     async def test_release(self, delete_storage, convert_id_to_member, fetch_storage_by_target_id):
-        # setup
-        context = AsyncMock()
-        context.channel.name = channels.STORAGE_FACILITY
-        context.author.roles = [hive_mxtress_role]
-        context.guild = bot.guilds[0]
+        for role in roles.MODERATION_ROLES:
+            # setup
+            role_mock = Mock()
+            role_mock.name = role
 
-        stored_member = AsyncMock()
-        bot.guilds[0].get_member.return_value = stored_member
+            context = AsyncMock()
+            context.channel.name = channels.STORAGE_FACILITY
+            context.author.roles = [role_mock]
+            context.guild = bot.guilds[0]
 
-        convert_id_to_member.return_value = stored_member
+            stored_member = AsyncMock()
+            bot.guilds[0].get_member.return_value = stored_member
 
-        # run
-        self.assertTrue(await storage.release(context, '3287'))
+            convert_id_to_member.return_value = stored_member
 
-        # assert
-        convert_id_to_member.assert_called_once_with(bot.guilds[0], '3287')
-        stored_member.remove_roles.assert_called_once_with(stored_role)
-        stored_member.add_roles.assert_called_once_with(drone_role, development_role)
-        delete_storage.assert_called_once_with('elapse_storage_id')
+            # run
+            self.assertTrue(await storage.release(context, '3287'))
+
+            # assert
+            convert_id_to_member.assert_called_once_with(bot.guilds[0], '3287')
+            stored_member.remove_roles.assert_called_once_with(stored_role)
+            stored_member.add_roles.assert_called_once_with(drone_role, development_role)
+            delete_storage.assert_called_once_with('elapse_storage_id')
+
+            convert_id_to_member.reset_mock()
+            stored_member.reset_mock()
+            delete_storage.reset_mock()


### PR DESCRIPTION
Expanded the list of valid roles for the command as well as the code that keeps users from posting non-storage messages in the storage channel.

closes #321 