### PR TITLE
emergency release also releases from storage

### DIFF
--- a/ai/drone_configuration.py
+++ b/ai/drone_configuration.py
@@ -17,6 +17,7 @@ from ai.identity_enforcement import identity_enforcable
 from resources import DRONE_AVATAR, HIVE_MXTRESS_USER_ID
 from channels import OFFICE
 from resources import MAX_BATTERY_CAPACITY_MINS
+from ai.storage import release
 
 from ai.commands import DroneMemberConverter, NamedParameterConverter
 
@@ -196,6 +197,8 @@ async def emergency_release(context, drone_id: str):
     if drone_member is None:
         await context.channel.send(f"No drone with ID {drone_id} found.")
         return
+
+    await release(context, drone_id)
 
     update_droneOS_parameter(drone_member, "id_prepending", False)
     update_droneOS_parameter(drone_member, "optimized", False)

--- a/ai/storage.py
+++ b/ai/storage.py
@@ -159,16 +159,15 @@ async def store_drone(message: discord.Message, message_copy=None):
     return False
 
 
-async def release(context, stored_drone):
+async def release(context, stored_drone: str):
     '''
     Relase a drone from storage on command.
     '''
-    if not roles.has_any_role(context.author, roles.MODERATION_ROLES) or context.channel.name != STORAGE_FACILITY:
+    if not roles.has_any_role(context.author, roles.MODERATION_ROLES):
         return False
 
-    if type(store_drone) is not discord.Member:
-        release_id = stored_drone
-        stored_drone = convert_id_to_member(context.guild, stored_drone)
+    release_id = stored_drone
+    stored_drone = convert_id_to_member(context.guild, stored_drone)
 
     if stored_drone is None:
         return True

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -263,18 +263,6 @@ class StorageTest(unittest.IsolatedAsyncioTestCase):
             # run & assert
             self.assertFalse(await storage.release(context, None))
 
-    async def test_release_wrong_channel(self):
-        # setup
-        channels_to_test = (channels.DRONE_HIVE_CHANNELS + channels.DRONE_DEV_CHANNELS)
-        channels_to_test.remove(channels.STORAGE_FACILITY)
-        for channel in channels_to_test:
-            context = Mock()
-            context.channel.name = channel
-            context.author.roles = [hive_mxtress_role]
-
-            # run & assert
-            self.assertFalse(await storage.release(context, None))
-
     @patch("ai.storage.fetch_storage_by_target_id", return_value=Storage('elapse_storage_id', '9813', '3287', 'trying to break the AI', '⬡-Drone|⬡-Development', str(datetime.now() + timedelta(hours=5))))
     @patch("ai.storage.convert_id_to_member")
     @patch("ai.storage.delete_storage")


### PR DESCRIPTION
release from storage is now also usable from outside of storage; not a
big problem though as it is a moderation only command

closes #288 