### PR TITLE
the length of of reply embeds is now limited

### DIFF
--- a/webhook.py
+++ b/webhook.py
@@ -56,10 +56,16 @@ async def webhook_if_message_altered(original: discord.Message, copy: MessageCop
                 attachments_as_files.append(discord.File(io.BytesIO(await attachment.read()), filename=attachment.filename))
         LOGGER.info("Attachments converted.")
 
+        # create an embed when responding to another message
         embed = None
         if original.reference:
             referenced_message: discord.Message = original.reference.resolved
             reply_text = f"[Reply to]({referenced_message.jump_url}): {referenced_message.content}"
+
+            # trim down overly long messages
+            if len(reply_text) > 277:
+                reply_text = reply_text[:277] + "..."
+
             embed = discord.Embed(color=0xff66ff, description=reply_text)
             embed.set_author(name=referenced_message.author.display_name, icon_url=referenced_message.author.avatar_url)
 


### PR DESCRIPTION
This truncates the content of embeds when replying to the length of a tweet to prevent spamming. I also added a test for basic creation of embeds when replying.

closes #325 