### PR TITLE
Bugfix/343 identity enforcement borked

### DIFF
--- a/test/test_amplify.py
+++ b/test/test_amplify.py
@@ -21,7 +21,7 @@ class TestAmplify(unittest.IsolatedAsyncioTestCase):
         amplification_cog = amplify.AmplificationCog()
 
         drone = AsyncMock()
-        drone.avatar_url = "Pretty avatar"
+        drone.avatar.url = "Pretty avatar"
         drone.display_name = "5890"
         id_converter.return_value = set(drone)
 

--- a/webhook.py
+++ b/webhook.py
@@ -44,7 +44,7 @@ async def webhook_if_message_altered(original: discord.Message, copy: MessageCop
     display_name_differs = original.author.display_name != copy.display_name
     avatar_differs = original.author.display_avatar.url != copy.avatar.url
     attachments_differ = original.attachments != copy.attachments
-    if any([content_differs, display_name_differs, avatar_differs, attachments_differ]):
+    if any([content_differs, display_name_differs, avatar_differs, attachments_differ, copy.identity_enforced]):
         LOGGER.info("Proxying altered message.")
 
         LOGGER.info("Converting all attachments")


### PR DESCRIPTION
The new identity_enforced field is now actually considered when deciding if a message needs to be webhooked.

Also an unrelated test was fixed, that I broke with a previous bugfix.

closes #343