### PR TITLE
construction of MessageCopy in main fixed

### DIFF
--- a/main.py
+++ b/main.py
@@ -175,7 +175,7 @@ async def on_message(message: discord.Message):
         await bot.process_commands(message)
         return
 
-    message_copy = MessageCopy(message.content, message.author.display_name, message.author.display_avatar, message.attachments)
+    message_copy = MessageCopy(content=message.content, display_name=message.author.display_name, avatar=message.author.display_avatar, attachments=message.attachments)
 
     LOGGER.info("Beginning message listener stack execution.")
     # use the listeners for bot messages or user messages


### PR DESCRIPTION
The added parameter in the middle of the parameter list messed with the one constructor call we had. Lesson learned, if you have so many parameters, use named parameters. Or use a strictly typed language (where this could still happen, it's just less likely).

closes #347 