### PR TITLE
set py-cord to version 2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-py-cord ~= 2.0.0rc1
+py-cord ~= 2.0.0
 glitch-this ~= 1.0.2


### PR DESCRIPTION
Hooray! The proper release is here. I do not expect incompatibilities