### PR TITLE
channel.recipient replaced with author.id and gave now a timezone

### DIFF
--- a/ai/add_voice.py
+++ b/ai/add_voice.py
@@ -5,7 +5,7 @@ from discord.ext.commands import Cog, command, dm_only
 
 from bot_utils import COMMAND_PREFIX
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 
 NOT_A_MEMBER = 'Access denied: you are not a member of this server.'
@@ -29,13 +29,13 @@ class AddVoiceCog(Cog):
 
 
 async def add_voice(context, guild: discord.Guild):
-    member = guild.get_member(context.channel.recipient.id)
+    member = guild.get_member(context.message.author.id)
 
     if member is None:
         await context.channel.send(NOT_A_MEMBER)
         return
 
-    if member.joined_at > datetime.now() - timedelta(weeks=2):
+    if member.joined_at > datetime.now(timezone.utc) - timedelta(weeks=2):
         await context.channel.send(ACCESS_DENIED)
         return
     if has_role(member, VOICE):

--- a/test/test_add_voice.py
+++ b/test/test_add_voice.py
@@ -1,7 +1,7 @@
 import unittest
 import ai.add_voice as add_voice
 from unittest.mock import Mock, AsyncMock
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from roles import VOICE
 
 
@@ -14,11 +14,11 @@ class AddVoiceTest(unittest.IsolatedAsyncioTestCase):
     async def test_not_long_enough(self):
         # setup
         context = AsyncMock()
-        context.channel.recipient.id = 1234
+        context.message.author.id = 1234
 
         member = AsyncMock()
         member.id = 1234
-        member.joined_at = datetime.now() - timedelta(weeks=1)
+        member.joined_at = datetime.now(timezone.utc) - timedelta(weeks=1)
         member.roles = []
 
         guild = Mock()
@@ -36,11 +36,11 @@ class AddVoiceTest(unittest.IsolatedAsyncioTestCase):
     async def test_already_granted(self):
         # setup
         context = AsyncMock()
-        context.channel.recipient.id = 1234
+        context.message.author.id = 1234
 
         member = AsyncMock()
         member.id = 1234
-        member.joined_at = datetime.now() - timedelta(weeks=13)
+        member.joined_at = datetime.now(timezone.utc) - timedelta(weeks=13)
         member.roles = [voice_role]
 
         guild = Mock()
@@ -58,11 +58,11 @@ class AddVoiceTest(unittest.IsolatedAsyncioTestCase):
     async def test_granted(self):
         # setup
         context = AsyncMock()
-        context.channel.recipient.id = 1234
+        context.message.author.id = 1234
 
         member = AsyncMock()
         member.id = 1234
-        member.joined_at = datetime.now() - timedelta(weeks=13)
+        member.joined_at = datetime.now(timezone.utc) - timedelta(weeks=13)
         member.roles = []
 
         guild = Mock()
@@ -80,11 +80,11 @@ class AddVoiceTest(unittest.IsolatedAsyncioTestCase):
     async def test_not_a_member(self):
         # setup
         context = AsyncMock()
-        context.channel.recipient.id = 1234
+        context.message.author.id = 1234
 
         member = AsyncMock()
         member.id = 1234
-        member.joined_at = datetime.now() - timedelta(weeks=13)
+        member.joined_at = datetime.now(timezone.utc) - timedelta(weeks=13)
         member.roles = []
 
         guild = Mock()


### PR DESCRIPTION
Slight changes in API made these necessary. Syntactically nothing really changed though.

closes #355 