### PR TITLE
bugfix/340 dm only documentation

### DIFF
--- a/ai/add_voice.py
+++ b/ai/add_voice.py
@@ -1,4 +1,5 @@
 import discord
+from resources import BRIEF_DM_ONLY
 from roles import VOICE, has_role
 from discord.utils import get
 from discord.ext.commands import Cog, command, dm_only
@@ -20,7 +21,7 @@ class AddVoiceCog(Cog):
         self.bot = bot
 
     @dm_only()
-    @command(usage=f'{COMMAND_PREFIX}request_voice_role')
+    @command(usage=f'{COMMAND_PREFIX}request_voice_role', brief=[BRIEF_DM_ONLY])
     async def request_voice_role(self, context):
         '''
         Gives you the Voice role and thus access to voice channels if you have been on the server for more than 2 weeks.

--- a/ai/amplify.py
+++ b/ai/amplify.py
@@ -12,7 +12,7 @@ from ai.identity_enforcement import identity_enforcable
 class AmplificationCog(Cog):
 
     @guild_only()
-    @command(brief="Hive Mxtress", usage=f'{COMMAND_PREFIX}amplify "Hello, little drone." #hexcorp-transmissions 9813 3287')
+    @command(brief=["Hive Mxtress"], usage=f'{COMMAND_PREFIX}amplify "Hello, little drone." #hexcorp-transmissions 9813 3287')
     async def amplify(self, context, message: str, target_channel: discord.TextChannel, *drones):
         '''
         Allows the Hive Mxtress to speak through other drones.

--- a/ai/amplify.py
+++ b/ai/amplify.py
@@ -4,7 +4,7 @@ import webhook
 from bot_utils import COMMAND_PREFIX, get_id
 from channels import OFFICE
 from discord.ext.commands import Cog, command, guild_only
-from resources import DRONE_AVATAR
+from resources import BRIEF_HIVE_MXTRESS, DRONE_AVATAR
 from roles import HIVE_MXTRESS, has_role
 from ai.identity_enforcement import identity_enforcable
 
@@ -12,7 +12,7 @@ from ai.identity_enforcement import identity_enforcable
 class AmplificationCog(Cog):
 
     @guild_only()
-    @command(brief=["Hive Mxtress"], usage=f'{COMMAND_PREFIX}amplify "Hello, little drone." #hexcorp-transmissions 9813 3287')
+    @command(brief=[BRIEF_HIVE_MXTRESS], usage=f'{COMMAND_PREFIX}amplify "Hello, little drone." #hexcorp-transmissions 9813 3287')
     async def amplify(self, context, message: str, target_channel: discord.TextChannel, *drones):
         '''
         Allows the Hive Mxtress to speak through other drones.

--- a/ai/battery.py
+++ b/ai/battery.py
@@ -3,7 +3,7 @@ from discord.ext import tasks, commands
 from db.drone_dao import is_drone, is_battery_powered, deincrement_battery_minutes_remaining, get_battery_percent_remaining, get_all_drone_batteries, get_battery_minutes_remaining, set_battery_minutes_remaining
 from id_converter import convert_ids_to_members
 import logging
-from resources import MAX_BATTERY_CAPACITY_MINS, DRONE_AVATAR, HOURS_OF_RECHARGE_PER_HOUR
+from resources import BRIEF_HIVE_MXTRESS, MAX_BATTERY_CAPACITY_MINS, DRONE_AVATAR, HOURS_OF_RECHARGE_PER_HOUR
 from roles import has_role, BATTERY_POWERED, BATTERY_DRAINED, HIVE_MXTRESS
 from discord.utils import get
 import webhook
@@ -22,7 +22,7 @@ class BatteryCog(commands.Cog):
         self.draining_batteries: Dict[str, int] = {}  # {drone_id: minutes of drain left}
         self.low_battery_drones: List[str] = []  # [drone_id]
 
-    @commands.command(usage=f"{COMMAND_PREFIX}energize 3287", brief=["Hive Mxtress"])
+    @commands.command(usage=f"{COMMAND_PREFIX}energize 3287", brief=[BRIEF_HIVE_MXTRESS])
     async def energize(self, context, *drone_ids):
         '''
         Hive Mxtress only command.

--- a/ai/battery.py
+++ b/ai/battery.py
@@ -22,7 +22,7 @@ class BatteryCog(commands.Cog):
         self.draining_batteries: Dict[str, int] = {}  # {drone_id: minutes of drain left}
         self.low_battery_drones: List[str] = []  # [drone_id]
 
-    @commands.command(usage=f"{COMMAND_PREFIX}energize 3287", brief="Hive Mxtress")
+    @commands.command(usage=f"{COMMAND_PREFIX}energize 3287", brief=["Hive Mxtress"])
     async def energize(self, context, *drone_ids):
         '''
         Hive Mxtress only command.

--- a/ai/drone_configuration.py
+++ b/ai/drone_configuration.py
@@ -35,7 +35,7 @@ MINUTES_PARAMETER = "minutes"
 class DroneConfigurationCog(Cog):
 
     @guild_only()
-    @command(brief="DroneOS", usage=f'{COMMAND_PREFIX}emergency_release 9813')
+    @command(brief=["DroneOS"], usage=f'{COMMAND_PREFIX}emergency_release 9813')
     async def emergency_release(self, context, drone_id: str):
         '''
         Lets moderators disable all DroneOS restrictions currently active on a drone.
@@ -44,7 +44,7 @@ class DroneConfigurationCog(Cog):
             await emergency_release(context, drone_id)
 
     @dm_only()
-    @command(brief="DroneOS", usage=f"{COMMAND_PREFIX}unassign")
+    @command(brief=["DroneOS"], usage=f"{COMMAND_PREFIX}unassign")
     async def unassign(self, context):
         '''
         Allows a drone to go back to the status of an Associate.
@@ -52,7 +52,7 @@ class DroneConfigurationCog(Cog):
         await unassign_drone(context.bot.guilds[0].get_member(context.author.id))
 
     @guild_only()
-    @command(brief="Hive Mxtress", usage=f'{COMMAND_PREFIX}rename 1234 3412')
+    @command(brief=["Hive Mxtress"], usage=f'{COMMAND_PREFIX}rename 1234 3412')
     async def rename(self, context, old_id, new_id):
         '''
         Allows the Hive Mxtress to change the ID of a drone.
@@ -61,7 +61,7 @@ class DroneConfigurationCog(Cog):
             await rename_drone(context, old_id, new_id)
 
     @guild_only()
-    @command(aliases=['tid'], brief="DroneOS", usage=f'{COMMAND_PREFIX}toggle_id_prepending 5890 9813')
+    @command(aliases=['tid'], brief=["DroneOS"], usage=f'{COMMAND_PREFIX}toggle_id_prepending 5890 9813')
     async def toggle_id_prepending(self, context, drones: Greedy[Union[discord.Member, DroneMemberConverter]], minutes: NamedParameterConverter(MINUTES_PARAMETER, int) = 0):
         '''
         Allows the Hive Mxtress or trusted users to enforce mandatory ID prepending upon specified drones.
@@ -77,7 +77,7 @@ class DroneConfigurationCog(Cog):
                                minutes)
 
     @guild_only()
-    @command(aliases=['optimize', 'toggle_speech_op', 'tso'], brief="DroneOS", usage=f'{COMMAND_PREFIX}toggle_speech_optimization 5890 9813')
+    @command(aliases=['optimize', 'toggle_speech_op', 'tso'], brief=["DroneOS"], usage=f'{COMMAND_PREFIX}toggle_speech_optimization 5890 9813')
     async def toggle_speech_optimization(self, context, drones: Greedy[Union[discord.Member, DroneMemberConverter]], minutes: NamedParameterConverter(MINUTES_PARAMETER, int) = 0):
         '''
         Lets the Hive Mxtress or trusted users toggle drone speech optimization.
@@ -93,7 +93,7 @@ class DroneConfigurationCog(Cog):
                                minutes)
 
     @guild_only()
-    @command(aliases=['tei'], brief="DroneOS", usage=f'{COMMAND_PREFIX}toggle_enforce_identity 5890 9813')
+    @command(aliases=['tei'], brief=["DroneOS"], usage=f'{COMMAND_PREFIX}toggle_enforce_identity 5890 9813')
     async def toggle_enforce_identity(self, context, drones: Greedy[Union[discord.Member, DroneMemberConverter]], minutes: NamedParameterConverter(MINUTES_PARAMETER, int) = 0):
         '''
         Lets the Hive Mxtress or trusted users toggle drone identity enforcement.
@@ -109,7 +109,7 @@ class DroneConfigurationCog(Cog):
                                minutes)
 
     @guild_only()
-    @command(aliases=['glitch', 'tdg'], brief="DroneOS", usage=f'{COMMAND_PREFIX}toggle_drone_glitch 9813 3287')
+    @command(aliases=['glitch', 'tdg'], brief=["DroneOS"], usage=f'{COMMAND_PREFIX}toggle_drone_glitch 9813 3287')
     async def toggle_drone_glitch(self, context, drones: Greedy[Union[discord.Member, DroneMemberConverter]], minutes: NamedParameterConverter(MINUTES_PARAMETER, int) = 0):
         '''
         Lets the Hive Mxtress or trusted users toggle drone glitch levels.
@@ -125,7 +125,7 @@ class DroneConfigurationCog(Cog):
                                minutes)
 
     @guild_only()
-    @command(aliases=['battery', 'tbp'], brief="DroneOS", usage=f'{COMMAND_PREFIX}toggle_battery_power 0001')
+    @command(aliases=['battery', 'tbp'], brief=["DroneOS"], usage=f'{COMMAND_PREFIX}toggle_battery_power 0001')
     async def toggle_battery_power(self, context, drones: Greedy[Union[discord.Member, DroneMemberConverter]], minutes: NamedParameterConverter(MINUTES_PARAMETER, int) = 0):
         '''
         Lets the Hive Mxtress or trusted users toggle whether or not a drone is battery powered.

--- a/ai/drone_configuration.py
+++ b/ai/drone_configuration.py
@@ -14,7 +14,7 @@ from display_names import update_display_name
 import webhook
 from bot_utils import get_id, COMMAND_PREFIX
 from ai.identity_enforcement import identity_enforcable
-from resources import DRONE_AVATAR, HIVE_MXTRESS_USER_ID
+from resources import BRIEF_DM_ONLY, BRIEF_DRONE_OS, BRIEF_HIVE_MXTRESS, DRONE_AVATAR, HIVE_MXTRESS_USER_ID
 from channels import OFFICE
 from resources import MAX_BATTERY_CAPACITY_MINS
 from ai.storage import release
@@ -35,7 +35,7 @@ MINUTES_PARAMETER = "minutes"
 class DroneConfigurationCog(Cog):
 
     @guild_only()
-    @command(brief=["DroneOS"], usage=f'{COMMAND_PREFIX}emergency_release 9813')
+    @command(brief=[BRIEF_DRONE_OS], usage=f'{COMMAND_PREFIX}emergency_release 9813')
     async def emergency_release(self, context, drone_id: str):
         '''
         Lets moderators disable all DroneOS restrictions currently active on a drone.
@@ -44,7 +44,7 @@ class DroneConfigurationCog(Cog):
             await emergency_release(context, drone_id)
 
     @dm_only()
-    @command(brief=["DroneOS"], usage=f"{COMMAND_PREFIX}unassign")
+    @command(brief=[BRIEF_DRONE_OS, BRIEF_DM_ONLY], usage=f"{COMMAND_PREFIX}unassign")
     async def unassign(self, context):
         '''
         Allows a drone to go back to the status of an Associate.
@@ -52,7 +52,7 @@ class DroneConfigurationCog(Cog):
         await unassign_drone(context.bot.guilds[0].get_member(context.author.id))
 
     @guild_only()
-    @command(brief=["Hive Mxtress"], usage=f'{COMMAND_PREFIX}rename 1234 3412')
+    @command(brief=[BRIEF_HIVE_MXTRESS], usage=f'{COMMAND_PREFIX}rename 1234 3412')
     async def rename(self, context, old_id, new_id):
         '''
         Allows the Hive Mxtress to change the ID of a drone.
@@ -61,7 +61,7 @@ class DroneConfigurationCog(Cog):
             await rename_drone(context, old_id, new_id)
 
     @guild_only()
-    @command(aliases=['tid'], brief=["DroneOS"], usage=f'{COMMAND_PREFIX}toggle_id_prepending 5890 9813')
+    @command(aliases=['tid'], brief=[BRIEF_DRONE_OS], usage=f'{COMMAND_PREFIX}toggle_id_prepending 5890 9813')
     async def toggle_id_prepending(self, context, drones: Greedy[Union[discord.Member, DroneMemberConverter]], minutes: NamedParameterConverter(MINUTES_PARAMETER, int) = 0):
         '''
         Allows the Hive Mxtress or trusted users to enforce mandatory ID prepending upon specified drones.
@@ -77,7 +77,7 @@ class DroneConfigurationCog(Cog):
                                minutes)
 
     @guild_only()
-    @command(aliases=['optimize', 'toggle_speech_op', 'tso'], brief=["DroneOS"], usage=f'{COMMAND_PREFIX}toggle_speech_optimization 5890 9813')
+    @command(aliases=['optimize', 'toggle_speech_op', 'tso'], brief=[BRIEF_DRONE_OS], usage=f'{COMMAND_PREFIX}toggle_speech_optimization 5890 9813')
     async def toggle_speech_optimization(self, context, drones: Greedy[Union[discord.Member, DroneMemberConverter]], minutes: NamedParameterConverter(MINUTES_PARAMETER, int) = 0):
         '''
         Lets the Hive Mxtress or trusted users toggle drone speech optimization.
@@ -93,7 +93,7 @@ class DroneConfigurationCog(Cog):
                                minutes)
 
     @guild_only()
-    @command(aliases=['tei'], brief=["DroneOS"], usage=f'{COMMAND_PREFIX}toggle_enforce_identity 5890 9813')
+    @command(aliases=['tei'], brief=[BRIEF_DRONE_OS], usage=f'{COMMAND_PREFIX}toggle_enforce_identity 5890 9813')
     async def toggle_enforce_identity(self, context, drones: Greedy[Union[discord.Member, DroneMemberConverter]], minutes: NamedParameterConverter(MINUTES_PARAMETER, int) = 0):
         '''
         Lets the Hive Mxtress or trusted users toggle drone identity enforcement.
@@ -109,7 +109,7 @@ class DroneConfigurationCog(Cog):
                                minutes)
 
     @guild_only()
-    @command(aliases=['glitch', 'tdg'], brief=["DroneOS"], usage=f'{COMMAND_PREFIX}toggle_drone_glitch 9813 3287')
+    @command(aliases=['glitch', 'tdg'], brief=[BRIEF_DRONE_OS], usage=f'{COMMAND_PREFIX}toggle_drone_glitch 9813 3287')
     async def toggle_drone_glitch(self, context, drones: Greedy[Union[discord.Member, DroneMemberConverter]], minutes: NamedParameterConverter(MINUTES_PARAMETER, int) = 0):
         '''
         Lets the Hive Mxtress or trusted users toggle drone glitch levels.
@@ -125,7 +125,7 @@ class DroneConfigurationCog(Cog):
                                minutes)
 
     @guild_only()
-    @command(aliases=['battery', 'tbp'], brief=["DroneOS"], usage=f'{COMMAND_PREFIX}toggle_battery_power 0001')
+    @command(aliases=['battery', 'tbp'], brief=[BRIEF_DRONE_OS], usage=f'{COMMAND_PREFIX}toggle_battery_power 0001')
     async def toggle_battery_power(self, context, drones: Greedy[Union[discord.Member, DroneMemberConverter]], minutes: NamedParameterConverter(MINUTES_PARAMETER, int) = 0):
         '''
         Lets the Hive Mxtress or trusted users toggle whether or not a drone is battery powered.

--- a/ai/drone_os_status.py
+++ b/ai/drone_os_status.py
@@ -13,7 +13,7 @@ LOGGER = logging.getLogger('ai')
 class DroneOsStatusCog(Cog):
 
     @dm_only()
-    @command(usage=f'{COMMAND_PREFIX}drone_status 9813', brief="DroneOS")
+    @command(usage=f'{COMMAND_PREFIX}drone_status 9813', brief=["DroneOS", "DM-Only"])
     async def drone_status(self, context, drone_id: str):
         '''
         Displays all the DroneOS information you have access to about a drone.

--- a/ai/drone_os_status.py
+++ b/ai/drone_os_status.py
@@ -4,7 +4,7 @@ import discord
 from discord.ext.commands import Cog, command, dm_only
 
 from db.drone_dao import fetch_drone_with_drone_id, get_trusted_users, get_battery_percent_remaining
-from resources import DRONE_AVATAR
+from resources import BRIEF_DM_ONLY, BRIEF_DRONE_OS, DRONE_AVATAR
 from bot_utils import COMMAND_PREFIX
 
 LOGGER = logging.getLogger('ai')
@@ -13,7 +13,7 @@ LOGGER = logging.getLogger('ai')
 class DroneOsStatusCog(Cog):
 
     @dm_only()
-    @command(usage=f'{COMMAND_PREFIX}drone_status 9813', brief=["DroneOS", "DM-Only"])
+    @command(usage=f'{COMMAND_PREFIX}drone_status 9813', brief=[BRIEF_DRONE_OS, BRIEF_DM_ONLY])
     async def drone_status(self, context, drone_id: str):
         '''
         Displays all the DroneOS information you have access to about a drone.

--- a/ai/forbidden_word.py
+++ b/ai/forbidden_word.py
@@ -38,7 +38,7 @@ class ForbiddenWordCog(Cog):
         self.bot = bot
 
     @guild_only()
-    @command(usage=f'{COMMAND_PREFIX}add_forbidden_word name pattern', brief="Hive Mxtress")
+    @command(usage=f'{COMMAND_PREFIX}add_forbidden_word name pattern', brief=["Hive Mxtress"])
     async def add_forbidden_word(self, context: Context, id: str, pattern: str):
         '''
         Lets the Hive Mxtress add a word to the list of forbidden words. The pattern is a regular expression.
@@ -50,7 +50,7 @@ class ForbiddenWordCog(Cog):
             await context.send("This command can only be used by the Hive Mxtress in their office.")
 
     @guild_only()
-    @command(usage=f'{COMMAND_PREFIX}list_forbidden_words', brief="Hive Mxtress")
+    @command(usage=f'{COMMAND_PREFIX}list_forbidden_words', brief=["Hive Mxtress"])
     async def list_forbidden_words(self, context: Context):
         '''
         List the currently configured forbidden words.
@@ -65,7 +65,7 @@ class ForbiddenWordCog(Cog):
             await context.send("This command can only be used by the Hive Mxtress in their office.")
 
     @guild_only()
-    @command(usage=f'{COMMAND_PREFIX}remove_forbidden_word name', brief="Hive Mxtress")
+    @command(usage=f'{COMMAND_PREFIX}remove_forbidden_word name', brief=["Hive Mxtress"])
     async def remove_forbidden_word(self, context: Context, id: str):
         '''
         Remove one of the forbidden words.

--- a/ai/forbidden_word.py
+++ b/ai/forbidden_word.py
@@ -10,6 +10,7 @@ from db.forbidden_word_dao import get_all_forbidden_words, insert_forbidden_word
 from discord.utils import get
 from bot_utils import COMMAND_PREFIX
 from emoji import DRONE_EMOJI
+from resources import BRIEF_HIVE_MXTRESS
 from roles import HIVE_MXTRESS, has_role
 LOGGER = logging.getLogger("ai")
 
@@ -38,7 +39,7 @@ class ForbiddenWordCog(Cog):
         self.bot = bot
 
     @guild_only()
-    @command(usage=f'{COMMAND_PREFIX}add_forbidden_word name pattern', brief=["Hive Mxtress"])
+    @command(usage=f'{COMMAND_PREFIX}add_forbidden_word name pattern', brief=[BRIEF_HIVE_MXTRESS])
     async def add_forbidden_word(self, context: Context, id: str, pattern: str):
         '''
         Lets the Hive Mxtress add a word to the list of forbidden words. The pattern is a regular expression.
@@ -50,7 +51,7 @@ class ForbiddenWordCog(Cog):
             await context.send("This command can only be used by the Hive Mxtress in their office.")
 
     @guild_only()
-    @command(usage=f'{COMMAND_PREFIX}list_forbidden_words', brief=["Hive Mxtress"])
+    @command(usage=f'{COMMAND_PREFIX}list_forbidden_words', brief=[BRIEF_HIVE_MXTRESS])
     async def list_forbidden_words(self, context: Context):
         '''
         List the currently configured forbidden words.
@@ -65,7 +66,7 @@ class ForbiddenWordCog(Cog):
             await context.send("This command can only be used by the Hive Mxtress in their office.")
 
     @guild_only()
-    @command(usage=f'{COMMAND_PREFIX}remove_forbidden_word name', brief=["Hive Mxtress"])
+    @command(usage=f'{COMMAND_PREFIX}remove_forbidden_word name', brief=[BRIEF_HIVE_MXTRESS])
     async def remove_forbidden_word(self, context: Context, id: str):
         '''
         Remove one of the forbidden words.

--- a/ai/storage.py
+++ b/ai/storage.py
@@ -41,7 +41,7 @@ class StorageCog(Cog):
         self.stored_role = None
 
     @guild_only()
-    @command(usage=f'{COMMAND_PREFIX}release 9813', brief="Hive Mxtress")
+    @command(usage=f'{COMMAND_PREFIX}release 9813', brief=["Hive Mxtress"])
     async def release(self, context, drone):
         '''
         Allows the Hive Mxtress to release a drone from storage.

--- a/ai/storage.py
+++ b/ai/storage.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 import discord
 from discord.ext.commands import Cog, command, guild_only
 from discord.ext import tasks
+from resources import BRIEF_HIVE_MXTRESS
 import roles
 from channels import STORAGE_CHAMBERS, STORAGE_FACILITY
 from db.data_objects import Storage as StorageDO
@@ -41,7 +42,7 @@ class StorageCog(Cog):
         self.stored_role = None
 
     @guild_only()
-    @command(usage=f'{COMMAND_PREFIX}release 9813', brief=["Hive Mxtress"])
+    @command(usage=f'{COMMAND_PREFIX}release 9813', brief=[BRIEF_HIVE_MXTRESS])
     async def release(self, context, drone):
         '''
         Allows the Hive Mxtress to release a drone from storage.

--- a/ai/trusted_user.py
+++ b/ai/trusted_user.py
@@ -14,7 +14,7 @@ LOGGER = logging.getLogger('ai')
 class TrustedUserCog(Cog):
 
     @dm_only()
-    @command(usage=f"{COMMAND_PREFIX}add_trusted_user \"A trusted user\"", brief="DroneOS")
+    @command(usage=f"{COMMAND_PREFIX}add_trusted_user \"A trusted user\"", brief=["DroneOS"])
     async def add_trusted_user(self, context, user_name: str):
         '''
         Add user with the given nickname as a trusted user.
@@ -24,7 +24,7 @@ class TrustedUserCog(Cog):
         await add_trusted_user(context, user_name)
 
     @dm_only()
-    @command(usage=f"{COMMAND_PREFIX}remove_trusted_user \"The untrusted user\"", brief="DroneOS")
+    @command(usage=f"{COMMAND_PREFIX}remove_trusted_user \"The untrusted user\"", brief=["DroneOS"])
     async def remove_trusted_user(self, context, user_name: str):
         '''
         Remove a given user from the list of trusted users.

--- a/ai/trusted_user.py
+++ b/ai/trusted_user.py
@@ -6,7 +6,7 @@ from discord.ext.commands import Cog, command, dm_only
 
 from bot_utils import COMMAND_PREFIX
 from db.drone_dao import get_trusted_users, set_trusted_users, get_discord_id_of_drone, fetch_all_drones_with_trusted_user, parse_trusted_users_text
-from resources import HIVE_MXTRESS_USER_ID
+from resources import BRIEF_DM_ONLY, BRIEF_DRONE_OS, HIVE_MXTRESS_USER_ID
 
 LOGGER = logging.getLogger('ai')
 
@@ -14,7 +14,7 @@ LOGGER = logging.getLogger('ai')
 class TrustedUserCog(Cog):
 
     @dm_only()
-    @command(usage=f"{COMMAND_PREFIX}add_trusted_user \"A trusted user\"", brief=["DroneOS"])
+    @command(usage=f"{COMMAND_PREFIX}add_trusted_user \"A trusted user\"", brief=[BRIEF_DRONE_OS, BRIEF_DM_ONLY])
     async def add_trusted_user(self, context, user_name: str):
         '''
         Add user with the given nickname as a trusted user.
@@ -24,7 +24,7 @@ class TrustedUserCog(Cog):
         await add_trusted_user(context, user_name)
 
     @dm_only()
-    @command(usage=f"{COMMAND_PREFIX}remove_trusted_user \"The untrusted user\"", brief=["DroneOS"])
+    @command(usage=f"{COMMAND_PREFIX}remove_trusted_user \"The untrusted user\"", brief=[BRIEF_DRONE_OS, BRIEF_DM_ONLY])
     async def remove_trusted_user(self, context, user_name: str):
         '''
         Remove a given user from the list of trusted users.

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import sys
 import logging
 from logging import handlers
 from discord.ext.commands import Bot, MissingRequiredArgument
+from discord.ext.commands.errors import PrivateMessageOnly
 from traceback import TracebackException
 from datetime import datetime, timedelta
 import asyncio
@@ -265,6 +266,8 @@ async def on_command_error(context, error):
         # missing arguments should not be that noisy and can be reported to the user
         LOGGER.info(f"Missing parameter {error.param.name} reported to user.")
         await context.send(f"`{error.param.name}` is a required argument that is missing.")
+    elif isinstance(error, PrivateMessageOnly):
+        await context.send("This message can only be used in DMs with the AI. Please consult the help for more information.")
     else:
         LOGGER.error(f"!!! Exception caught in {context.command} command !!!")
         LOGGER.info("".join(TracebackException(type(error), error, error.__traceback__, limit=None).format(chain=True)))

--- a/main.py
+++ b/main.py
@@ -42,7 +42,7 @@ from bot_utils import COMMAND_PREFIX
 from db import database
 from db import drone_dao
 # Constants
-from resources import DRONE_AVATAR, HIVE_MXTRESS_AVATAR, HEXCORP_AVATAR
+from resources import DRONE_AVATAR, HIVE_MXTRESS_AVATAR, HEXCORP_AVATAR, BRIEF_DM_ONLY, BRIEF_HIVE_MXTRESS, BRIEF_DRONE_OS
 # Data objects
 from ai.data_objects import MessageCopy
 
@@ -159,12 +159,12 @@ async def help(context):
         command_description += f"\n`{command.usage}`" if command.usage is not None else "\n`No usage string available.`"
 
         if command.brief is not None:
-            if "DM-Only" in command.brief:
+            if BRIEF_DM_ONLY in command.brief:
                 command_description += "\n This command can only be used in DMs with the AI."
 
-            if "Hive Mxtress" in command.brief:
+            if BRIEF_HIVE_MXTRESS in command.brief:
                 Hive_Mxtress_card.add_field(name=command_name, value=command_description, inline=False)
-            elif "DroneOS" in command.brief:
+            elif BRIEF_DRONE_OS in command.brief:
                 droneOS_card.add_field(name=command_name, value=command_description, inline=False)
             else:
                 commands_card.add_field(name=command_name, value=command_description, inline=False)

--- a/main.py
+++ b/main.py
@@ -157,12 +157,16 @@ async def help(context):
         command_description = command.help if command.help is not None else "A naughty dev drone forgot to add a command description."
         command_description += f"\n`{command.usage}`" if command.usage is not None else "\n`No usage string available.`"
 
-        if command.brief == "Hive Mxtress":
-            Hive_Mxtress_card.add_field(name=command_name, value=command_description, inline=False)
-        elif command.brief == "DroneOS":
-            droneOS_card.add_field(name=command_name, value=command_description, inline=False)
-        else:
-            commands_card.add_field(name=command_name, value=command_description, inline=False)
+        if command.brief is not None:
+            if "DM-Only" in command.brief:
+                command_description += "\n This command can only be used in DMs with the AI."
+
+            if "Hive Mxtress" in command.brief:
+                Hive_Mxtress_card.add_field(name=command_name, value=command_description, inline=False)
+            elif "DroneOS" in command.brief:
+                droneOS_card.add_field(name=command_name, value=command_description, inline=False)
+            else:
+                commands_card.add_field(name=command_name, value=command_description, inline=False)
 
     await context.author.send(embed=commands_card)
     await context.author.send(embed=droneOS_card)

--- a/resources.py
+++ b/resources.py
@@ -102,3 +102,7 @@ code_map = {
     '450': 'Error',
     '500': 'Response :: Negative.',
 }
+
+BRIEF_HIVE_MXTRESS = "Hive Mxtress"
+BRIEF_DM_ONLY = "DM-Only"
+BRIEF_DRONE_OS = "DroneOS"


### PR DESCRIPTION
The help command now shows for commands if they are only to be used if DMs with the AI. Additionally when using a DM only command in the server, the AI will respond with an error directly, saying that this command can only be used in DMs.

closes #340 