### PR TITLE
bugfix/366 glitched react

### DIFF
--- a/ai/data_objects.py
+++ b/ai/data_objects.py
@@ -1,5 +1,5 @@
 from typing import Iterable, Optional
-from discord import Attachment, Asset
+from discord import Attachment, Asset, Reaction
 
 
 class MessageCopy:
@@ -15,10 +15,12 @@ class MessageCopy:
         display_name: Optional[str] = None,
         avatar: Optional[Asset] = None,
         identity_enforced: bool = False,
-        attachments: Iterable[Attachment] = []
+        attachments: Iterable[Attachment] = [],
+        reactions: Iterable[Reaction] = []
     ):
         self.content = content
         self.display_name = display_name
         self.avatar = avatar
         self.identity_enforced = identity_enforced
         self.attachments = attachments
+        self.reactions = reactions

--- a/ai/react.py
+++ b/ai/react.py
@@ -6,8 +6,7 @@ from roles import has_role, DRONE
 
 
 PATTERN_REACTS = {
-    r'^(\d{4}) :: Code `109` :: .*': 'gooddrone',
-    r'^(\d{4}) :: <.*> :: Code `109` :: .*': 'gooddrone'
+    r'^(\d{4}) :: 109( :: .*)?': 'gooddrone'
 }
 
 

--- a/main.py
+++ b/main.py
@@ -103,6 +103,7 @@ message_listeners = [
     identity_enforcement.enforce_identity,
     forbidden_word.deny_thoughts,
     battery_cog.append_battery_indicator,
+    react.parse_for_reactions,
     glitch_message.glitch_if_applicable,
     respond.respond_to_question,
     storage.store_drone,
@@ -110,9 +111,7 @@ message_listeners = [
 ]
 
 # register message listeners that take messages sent by bots
-bot_message_listeners = [
-    react.parse_for_reactions
-]
+bot_message_listeners = []
 
 # Cogs that do not use tasks.
 bot.add_cog(emote.EmoteCog())
@@ -184,7 +183,7 @@ async def on_message(message: discord.Message):
         await bot.process_commands(message)
         return
 
-    message_copy = MessageCopy(content=message.content, display_name=message.author.display_name, avatar=message.author.display_avatar, attachments=message.attachments)
+    message_copy = MessageCopy(content=message.content, display_name=message.author.display_name, avatar=message.author.display_avatar, attachments=message.attachments, reactions=message.reactions)
 
     LOGGER.info("Beginning message listener stack execution.")
     # use the listeners for bot messages or user messages

--- a/test/test_react.py
+++ b/test/test_react.py
@@ -38,7 +38,23 @@ class ReactTest(unittest.IsolatedAsyncioTestCase):
         guild.emojis = [GOOD_DRONE_EMOTE, RUBBERHEART_EMOTE]
 
         message = AsyncMock()
-        message.content = "9813 :: Code `109` :: Error :: Keysmash, drone flustered."
+        message.content = "9813 :: 109"
+        message.guild = guild
+
+        # run
+        result = await react.parse_for_reactions(message, None)
+
+        # assert
+        self.assertFalse(result, "parse_for_reactions should always return False.")
+        message.add_reaction.assert_called_once_with(GOOD_DRONE_EMOTE)
+
+    async def test_reaction_additional_status(self):
+        # init
+        guild = Mock()
+        guild.emojis = [GOOD_DRONE_EMOTE, RUBBERHEART_EMOTE]
+
+        message = AsyncMock()
+        message.content = "9813 :: 109 :: beep boop"
         message.guild = guild
 
         # run


### PR DESCRIPTION
"Good drone" reacts are now added to the original message a drone sends, but these reacts are then added to the webhooked message, when the original gets removed. This approach is more powerful as it allows us to add reactions to webhooked messages based on the raw input from the user. Any modifications done by the webhook logic do not impede with the the reaction logic anymore.

closes #366