### PR TITLE
moderators can now also see drone status

### DIFF
--- a/ai/drone_os_status.py
+++ b/ai/drone_os_status.py
@@ -49,7 +49,7 @@ def get_status(drone_id: str, requesting_user: int, context) -> discord.Embed:
     if is_trusted_user:
         embed.description = "You are registered as a trusted user of this drone and have access to its data."
     if is_moderation:
-        embed.description = "You are a moderator and have access to this drones' data."
+        embed.description = "You are a moderator and have access to this drone's data."
     if is_drone_self:
         embed.description = f"Welcome, ⬡-Drone #{drone_id}"
 

--- a/ai/drone_os_status.py
+++ b/ai/drone_os_status.py
@@ -6,6 +6,7 @@ from discord.ext.commands import Cog, command
 from db.drone_dao import fetch_drone_with_drone_id, get_trusted_users, get_battery_percent_remaining
 from resources import BRIEF_DRONE_OS, DRONE_AVATAR
 from bot_utils import COMMAND_PREFIX
+from roles import MODERATION_ROLES, has_any_role
 
 LOGGER = logging.getLogger('ai')
 
@@ -37,21 +38,32 @@ def get_status(drone_id: str, requesting_user: int, context) -> discord.Embed:
     trusted_users = get_trusted_users(drone.id)
     is_trusted_user = requesting_user in trusted_users
     is_drone_self = requesting_user == drone.id
+    is_moderation = has_any_role(context.author, MODERATION_ROLES)
 
-    if not is_trusted_user and not is_drone_self:
+    # return early when this request is not authorized
+    if not is_trusted_user and not is_drone_self and not is_moderation:
         embed.description = "You are not registered as a trusted user of this drone."
+        return embed
 
-    if is_trusted_user or is_drone_self:
-        embed.description = "You are registered as a trusted user of this drone and have access to its data." if is_trusted_user else f"Welcome, ⬡-Drone #{drone_id}"
-        embed = embed.set_thumbnail(url=DRONE_AVATAR) \
-            .set_footer(text="HexCorp DroneOS") \
-            .add_field(name="Optimized", value=boolean_to_enabled_disabled(drone.optimized)) \
-            .add_field(name="Glitched", value=boolean_to_enabled_disabled(drone.glitched)) \
-            .add_field(name="ID prepending required", value=boolean_to_enabled_disabled(drone.id_prepending)) \
-            .add_field(name="Identity enforced", value=boolean_to_enabled_disabled(drone.identity_enforcement)) \
-            .add_field(name="Battery powered", value=boolean_to_enabled_disabled(drone.is_battery_powered)) \
-            .add_field(name="Battery percentage", value=f"{get_battery_percent_remaining(battery_minutes = drone.battery_minutes)}%")
+    # assemble description
+    if is_trusted_user:
+        embed.description = "You are registered as a trusted user of this drone and have access to its data."
+    if is_moderation:
+        embed.description = "You are a moderator and have access to this drones' data."
+    if is_drone_self:
+        embed.description = f"Welcome, ⬡-Drone #{drone_id}"
 
+    # assemble embed content
+    embed = embed.set_thumbnail(url=DRONE_AVATAR) \
+        .set_footer(text="HexCorp DroneOS") \
+        .add_field(name="Optimized", value=boolean_to_enabled_disabled(drone.optimized)) \
+        .add_field(name="Glitched", value=boolean_to_enabled_disabled(drone.glitched)) \
+        .add_field(name="ID prepending required", value=boolean_to_enabled_disabled(drone.id_prepending)) \
+        .add_field(name="Identity enforced", value=boolean_to_enabled_disabled(drone.identity_enforcement)) \
+        .add_field(name="Battery powered", value=boolean_to_enabled_disabled(drone.is_battery_powered)) \
+        .add_field(name="Battery percentage", value=f"{get_battery_percent_remaining(battery_minutes = drone.battery_minutes)}%")
+
+    # create list of trusted users
     if is_drone_self:
         trusted_usernames = []
         for trusted_user in trusted_users:

--- a/test/test_drone_os_status.py
+++ b/test/test_drone_os_status.py
@@ -168,7 +168,7 @@ class DroneOSStatusTest(unittest.IsolatedAsyncioTestCase):
 
         # assert
         self.assertIsNotNone(status)
-        self.assertEqual("You are a moderator and have access to this drones' data.", status.description)
+        self.assertEqual("You are a moderator and have access to this drone's data.", status.description)
         self.assertEqual("Optimized", status.fields[0].name)
         self.assertEqual("Enabled", status.fields[0].value)
         self.assertEqual("Glitched", status.fields[1].name)

--- a/test/test_drone_os_status.py
+++ b/test/test_drone_os_status.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest.mock import patch, Mock
 from ai.drone_os_status import get_status
+import roles
 
 
 class DroneOSStatusTest(unittest.IsolatedAsyncioTestCase):
@@ -29,7 +30,15 @@ class DroneOSStatusTest(unittest.IsolatedAsyncioTestCase):
         fetch_drone_with_drone_id.return_value = drone
         get_trusted_users.return_value = []
 
+        associate_role = Mock()
+        associate_role.name = roles.ASSOCIATE
+
+        associate_user = Mock()
+        associate_user.display_name = "An associate"
+        associate_user.roles = [associate_role]
+
         context = Mock()
+        context.author = associate_user
 
         # run
         status = get_status('9813', 782638723, context)
@@ -55,7 +64,15 @@ class DroneOSStatusTest(unittest.IsolatedAsyncioTestCase):
         requesting_user_id = 782638723
         get_trusted_users.return_value = [requesting_user_id]
 
+        associate_role = Mock()
+        associate_role.name = roles.ASSOCIATE
+
+        associate_user = Mock()
+        associate_user.display_name = "An associate"
+        associate_user.roles = [associate_role]
+
         context = Mock()
+        context.author = associate_user
 
         # run
         status = get_status('9813', requesting_user_id, context)
@@ -91,7 +108,15 @@ class DroneOSStatusTest(unittest.IsolatedAsyncioTestCase):
         trusted_user = Mock()
         trusted_user.display_name = "A trustworthy user"
 
+        drone_role = Mock()
+        drone_role.name = roles.ASSOCIATE
+
+        drone_user = Mock()
+        drone_user.display_name = "⬡-Drone #9813"
+        drone_user.roles = [drone_role]
+
         context = Mock()
+        context.author = drone_user
         context.bot.get_user.return_value = trusted_user
 
         # run
@@ -112,3 +137,44 @@ class DroneOSStatusTest(unittest.IsolatedAsyncioTestCase):
         fetch_drone_with_drone_id.assert_called_once_with('9813')
         get_trusted_users.assert_called_once_with(drone.id)
         context.bot.get_user.assert_called_once_with(trusted_user_id)
+
+    @patch("ai.drone_os_status.get_trusted_users")
+    @patch("ai.drone_os_status.fetch_drone_with_drone_id")
+    def test_status_as_moderator(self, fetch_drone_with_drone_id, get_trusted_users):
+        # setup
+        drone = Mock()
+        drone.id = 7263486234
+        drone.optimized = True
+        drone.glitched = False
+        drone.id_prepending = False
+        drone.battery_minutes = 300
+
+        fetch_drone_with_drone_id.return_value = drone
+        requesting_user_id = 782638723
+        get_trusted_users.return_value = []
+
+        moderation_role = Mock()
+        moderation_role.name = roles.MODERATION
+
+        moderator_user = Mock()
+        moderator_user.display_name = "A moderator"
+        moderator_user.roles = [moderation_role]
+
+        context = Mock()
+        context.author = moderator_user
+
+        # run
+        status = get_status('9813', requesting_user_id, context)
+
+        # assert
+        self.assertIsNotNone(status)
+        self.assertEqual("You are a moderator and have access to this drones' data.", status.description)
+        self.assertEqual("Optimized", status.fields[0].name)
+        self.assertEqual("Enabled", status.fields[0].value)
+        self.assertEqual("Glitched", status.fields[1].name)
+        self.assertEqual("Disabled", status.fields[1].value)
+        self.assertEqual("ID prepending required", status.fields[2].name)
+        self.assertEqual("Disabled", status.fields[2].value)
+
+        fetch_drone_with_drone_id.assert_called_once_with('9813')
+        get_trusted_users.assert_called_once_with(drone.id)


### PR DESCRIPTION
closes #233 

also rearranged the assembly of status embeds a bit, because it was getting messy