### PR TITLE
bumped pycord to 2.4.1 and python to 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.16-slim-bullseye
+FROM python:3.11.3-slim-bullseye
 
 COPY requirements.txt /root
 RUN pip3 install -r /root/requirements.txt
@@ -7,4 +7,4 @@ WORKDIR /var/opt/HexCorpDiscordAI
 
 COPY . .
 
-CMD python3.8 main.py ${DISCORD_ACCESS_TOKEN}
+CMD python3.11 main.py ${DISCORD_ACCESS_TOKEN}

--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 
 ## Requirements
 
-- Python 3.8
+- Python 3.11
 - pip
 - python-setuptools
-- discord.py ~= 1.6.0
+- pycord 2.4.1
 
 To install all Python dependencies you can use pip. Just enter
 `pip install -r requirements.txt` in the project directory.
 
-Note: We use Python 3.8+ so if your system does have multiple versions
+Note: We use Python 3.11+ so if your system does have multiple versions
 installed, you may have to specify which installation to use e.g.
-`python3.8` and `pip3.8`.
+`python3.11` and `pip3.11`.
 
 ## Building and deploying with Docker
 
@@ -45,7 +45,7 @@ docker run \
 To start the bot you can enter the following command in the project root:
 
 ```bash
-python3.8 main.py <access_token>
+python3.11 main.py <access_token>
 ```
 
 ### Updating

--- a/install.sh
+++ b/install.sh
@@ -1,12 +1,8 @@
-#add nice alias for sourcing
-echo 'alias src="source env/bin/activate"' >> ~/.profile 
-source ~/.profile 
-
 #install venv and requirements
-sudo apt install python3.8 python3.8-venv
-python3.8 -m venv env
+sudo apt install python3.11 python3.11-venv
+python3.11 -m venv env
 source env/bin/activate
-pip3.8 install -r requirements.txt
+pip install -r requirements.txt
 
 #help text
-echo "just run 'src' whenever you enter the directory now!"
+echo "just run 'env/bin/activate' whenever you enter the directory now!"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-py-cord ~= 2.0.0
+py-cord ~= 2.4.1
 glitch-this ~= 1.0.2


### PR DESCRIPTION
pycord 2.4.1 is the most up to date version available right now (see https://docs.pycord.dev/en/stable/changelog.html on 2023-04-08) and supports up to Python 3.11 (introduced in pycord 2.3.0).
I bumped the versions where I found them, read through the changelog to try and spot obvious problems, ran the tests, connected to the testserver and built and ran a Docker container with the new versions. Worked really well.

This may break your development environment if you use Python 3.8 but 3.11 is available through normal repositories. Also don't forget to install the new version of pycord locally after this gets merged.

closes #381 