### PR TITLE
drone_status is usable in DMs again

### DIFF
--- a/ai/drone_os_status.py
+++ b/ai/drone_os_status.py
@@ -35,10 +35,12 @@ def get_status(drone_id: str, requesting_user: int, context) -> discord.Embed:
         .set_thumbnail(url=DRONE_AVATAR) \
         .set_footer(text="HexCorp DroneOS")
 
+    member = context.author if isinstance(context.author, discord.Member) else context.bot.guilds[0].get_member(context.author.id)
+
     trusted_users = get_trusted_users(drone.id)
     is_trusted_user = requesting_user in trusted_users
     is_drone_self = requesting_user == drone.id
-    is_moderation = has_any_role(context.author, MODERATION_ROLES)
+    is_moderation = has_any_role(member, MODERATION_ROLES)
 
     # return early when this request is not authorized
     if not is_trusted_user and not is_drone_self and not is_moderation:

--- a/test/test_drone_os_status.py
+++ b/test/test_drone_os_status.py
@@ -37,8 +37,12 @@ class DroneOSStatusTest(unittest.IsolatedAsyncioTestCase):
         associate_user.display_name = "An associate"
         associate_user.roles = [associate_role]
 
+        guild = Mock()
+        guild.get_member.return_value = associate_user
+
         context = Mock()
         context.author = associate_user
+        context.bot.guilds = [guild]
 
         # run
         status = get_status('9813', 782638723, context)
@@ -71,8 +75,12 @@ class DroneOSStatusTest(unittest.IsolatedAsyncioTestCase):
         associate_user.display_name = "An associate"
         associate_user.roles = [associate_role]
 
+        guild = Mock()
+        guild.get_member.return_value = associate_user
+
         context = Mock()
         context.author = associate_user
+        context.bot.guilds = [guild]
 
         # run
         status = get_status('9813', requesting_user_id, context)
@@ -115,9 +123,13 @@ class DroneOSStatusTest(unittest.IsolatedAsyncioTestCase):
         drone_user.display_name = "⬡-Drone #9813"
         drone_user.roles = [drone_role]
 
+        guild = Mock()
+        guild.get_member.return_value = drone_user
+
         context = Mock()
         context.author = drone_user
         context.bot.get_user.return_value = trusted_user
+        context.bot.guilds = [guild]
 
         # run
         status = get_status('9813', drone.id, context)
@@ -160,8 +172,12 @@ class DroneOSStatusTest(unittest.IsolatedAsyncioTestCase):
         moderator_user.display_name = "A moderator"
         moderator_user.roles = [moderation_role]
 
+        guild = Mock()
+        guild.get_member.return_value = moderator_user
+
         context = Mock()
         context.author = moderator_user
+        context.bot.guilds = [guild]
 
         # run
         status = get_status('9813', requesting_user_id, context)


### PR DESCRIPTION
context.author only returns a Member when the message was sent in a server but only a Member has roles. So for this code to work in DMs (where context.author returns a User without roles) you need to convert the User to a Member for a specific Guild. We can use Guild 0 because the AI is only on our one server.

closes #388 