### PR TITLE
bumped ubuntu and python version for CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       # get latest code
       - uses: actions/checkout@v2
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.11
       # install all necessary dependencies
       - name: Install dependencies
         run: |


### PR DESCRIPTION
We were still running with Ubuntu 20.04 as image and Python 3.8 in our CI which worked okay but this should very much be updated to reflect the production environment.

Only needed the version bumps, everything kept working fine.