### PR TITLE
 battery indicator and server avatar for amplification

### DIFF
--- a/ai/amplify.py
+++ b/ai/amplify.py
@@ -28,7 +28,7 @@ class AmplificationCog(Cog):
 
         for drone in member_drones:
 
-            formatted_message = generate_battery_message(f"{get_id(drone.display_name)} :: {message}")
+            formatted_message = generate_battery_message(drone, f"{get_id(drone.display_name)} :: {message}")
 
             await webhook.proxy_message_by_webhook(message_content=formatted_message,
                                                    message_username=drone.display_name,

--- a/ai/amplify.py
+++ b/ai/amplify.py
@@ -1,12 +1,14 @@
 import discord
+from discord.ext.commands import Cog, command, guild_only
+
 import id_converter
 import webhook
+from ai.battery import generate_battery_message
+from ai.identity_enforcement import identity_enforcable
 from bot_utils import COMMAND_PREFIX, get_id
 from channels import OFFICE
-from discord.ext.commands import Cog, command, guild_only
 from resources import BRIEF_HIVE_MXTRESS, DRONE_AVATAR
 from roles import HIVE_MXTRESS, has_role
-from ai.identity_enforcement import identity_enforcable
 
 
 class AmplificationCog(Cog):
@@ -25,8 +27,11 @@ class AmplificationCog(Cog):
         channel_webhook = await webhook.get_webhook_for_channel(target_channel)
 
         for drone in member_drones:
-            await webhook.proxy_message_by_webhook(message_content=f"{get_id(drone.display_name)} :: {message}",
+
+            formatted_message = generate_battery_message(f"{get_id(drone.display_name)} :: {message}")
+
+            await webhook.proxy_message_by_webhook(message_content=formatted_message,
                                                    message_username=drone.display_name,
-                                                   message_avatar=drone.avatar.url if not identity_enforcable(drone, channel=target_channel) else DRONE_AVATAR,
+                                                   message_avatar=drone.display_avatar.url if not identity_enforcable(drone, channel=target_channel) else DRONE_AVATAR,
                                                    webhook=channel_webhook)
         return True

--- a/ai/battery.py
+++ b/ai/battery.py
@@ -170,7 +170,7 @@ class BatteryCog(commands.Cog):
                         continue
 
 
-def add_battery_indicator_to_copy(message: Message, message_copy: MessageCopy):
+async def add_battery_indicator_to_copy(message: Message, message_copy: MessageCopy):
     '''
     Prepends battery indicator emoji to a MessageCopy if the drone
     which sent the original message is battery powered.

--- a/ai/battery.py
+++ b/ai/battery.py
@@ -2,6 +2,8 @@ import logging
 import re
 from copy import deepcopy
 from typing import Dict, List
+from ai.data_objects import MessageCopy
+from db.data_objects import Storage
 
 import emoji
 import webhook
@@ -11,7 +13,7 @@ from db.drone_dao import (deincrement_battery_minutes_remaining,
                           get_battery_minutes_remaining,
                           get_battery_percent_remaining, is_battery_powered,
                           is_drone, set_battery_minutes_remaining)
-from discord import Member
+from discord import Emoji, Guild, Member, Message
 from discord.ext import commands, tasks
 from discord.utils import get
 from id_converter import convert_ids_to_members
@@ -167,44 +169,62 @@ class BatteryCog(commands.Cog):
                     except ValueError:
                         continue
 
-    async def append_battery_indicator(self, message, message_copy):
-        '''
-        Prepends battery indicator emoji to drone's message if they are
-        battery powered. The indicator is placed after the ID prepend
-        if the message includes it
-        '''
 
-        if not is_battery_powered(message.author):
-            return False
+def add_battery_indicator_to_copy(message: Message, message_copy: MessageCopy):
+    '''
+    Prepends battery indicator emoji to a MessageCopy if the drone
+    which sent the original message is battery powered.
+    The indicator is placed after the ID prepend if the message includes it.
+    '''
+    message_copy.content = generate_battery_message(message.author, message_copy.content)
 
-        id_prepending_regex = re.compile(r'(\d{4} ::)(.+)', re.DOTALL)
-
-        battery_percentage = get_battery_percent_remaining(message.author)
-
-        LOGGER.debug(f"Battery percentage: {battery_percentage}")
-
-        if battery_percentage <= 100 and battery_percentage >= 75:
-            battery_emoji = get(message.guild.emojis, name=emoji.BATTERY_FULL)
-        elif battery_percentage <= 75 and battery_percentage >= 25:
-            battery_emoji = get(message.guild.emojis, name=emoji.BATTERY_MID)
-        elif battery_percentage <= 24 and battery_percentage >= 10:
-            battery_emoji = get(message.guild.emojis, name=emoji.BATTERY_LOW)
-        elif battery_percentage <= 9:
-            battery_emoji = get(message.guild.emojis, name=emoji.BATTERY_EMPTY)
-        else:
-            battery_emoji = "[BATTERY ERROR]"
-
-        id_prepending_message = id_prepending_regex.match(message_copy.content)
-
-        if id_prepending_message:
-            message_copy.content = f"{id_prepending_message.group(1)} {str(battery_emoji)} ::{id_prepending_message.group(2)}"
-        else:
-            message_copy.content = f"{str(battery_emoji)} :: {message_copy.content}"
-
-        return False
+    return False
 
 
-def recharge_battery(storage_record):
+def generate_battery_message(member: Member, original_content: str) -> str:
+    '''
+    Assembles a message content with a battery emoji for a given Guild Member.
+    Returns the original content if the drone is not battery powered.
+    '''
+
+    if not is_battery_powered(member):
+        return original_content
+
+    battery_percentage = get_battery_percent_remaining(member)
+    battery_emoji = determine_battery_emoji(battery_percentage, member.guild)
+
+    id_prepending_regex = re.compile(r'(\d{4} ::)(.+)', re.DOTALL)
+
+    id_prepending_message = id_prepending_regex.match(original_content)
+
+    if id_prepending_message:
+        return f"{id_prepending_message.group(1)} {str(battery_emoji)} ::{id_prepending_message.group(2)}"
+    else:
+        return f"{str(battery_emoji)} :: {original_content}"
+
+
+def determine_battery_emoji(battery_percentage: int, guild: Guild) -> Emoji | str:
+    '''
+    Determines which battery emoji should be used according to the charge of the drone.
+    '''
+
+    if battery_percentage <= 100 and battery_percentage >= 75:
+        return get(guild.emojis, name=emoji.BATTERY_FULL)
+    elif battery_percentage <= 75 and battery_percentage >= 25:
+        return get(guild.emojis, name=emoji.BATTERY_MID)
+    elif battery_percentage <= 24 and battery_percentage >= 10:
+        return get(guild.emojis, name=emoji.BATTERY_LOW)
+    elif battery_percentage <= 9:
+        return get(guild.emojis, name=emoji.BATTERY_EMPTY)
+    else:
+        return "[BATTERY ERROR]"
+
+
+def recharge_battery(storage_record: Storage):
+    '''
+    Fills the battery of a drone in storage up to max.
+    '''
+
     try:
         current_minutes_remaining = get_battery_minutes_remaining(drone_id=storage_record.target_id)
         set_battery_minutes_remaining(drone_id=storage_record.target_id, minutes=min(MAX_BATTERY_CAPACITY_MINS, current_minutes_remaining + (60 * HOURS_OF_RECHARGE_PER_HOUR)))
@@ -215,5 +235,9 @@ def recharge_battery(storage_record):
 
 
 def drain_battery(member: Member):
+    '''
+    Reduces the battery charge of a drone by 10%.
+    '''
+
     minutes_remaining = get_battery_minutes_remaining(member=member)
     set_battery_minutes_remaining(member=member, minutes=minutes_remaining - MAX_BATTERY_CAPACITY_MINS / 10)

--- a/main.py
+++ b/main.py
@@ -104,7 +104,7 @@ message_listeners = [
     speech_optimization.optimize_speech,
     identity_enforcement.enforce_identity,
     forbidden_word.deny_thoughts,
-    battery_cog.append_battery_indicator,
+    battery.add_battery_indicator_to_copy,
     react.parse_for_reactions,
     glitch_message.glitch_if_applicable,
     respond.respond_to_question,

--- a/test/test_amplify.py
+++ b/test/test_amplify.py
@@ -45,7 +45,7 @@ class TestAmplify(unittest.IsolatedAsyncioTestCase):
             webhook=webhook
         )
 
-        generate_battery_message.assert_called_once_with("3287 :: Beep boop!")
+        generate_battery_message.assert_called_once_with(drone, "3287 :: Beep boop!")
 
     @patch("ai.amplify.has_role")
     async def test_does_not_work_if_not_Mxtress(self, has_role):

--- a/test/test_amplify.py
+++ b/test/test_amplify.py
@@ -9,20 +9,21 @@ class TestAmplify(unittest.IsolatedAsyncioTestCase):
     The amplify command...
     '''
 
+    @patch("ai.amplify.generate_battery_message")
     @patch("ai.amplify.identity_enforcable", return_value=False)
     @patch("ai.amplify.has_role", return_value=True)
     @patch("ai.amplify.webhook.get_webhook_for_channel")
     @patch("ai.amplify.id_converter.convert_ids_to_members")
     @patch("ai.amplify.webhook.proxy_message_by_webhook")
-    async def test_webhook_called_with_appropriate_message(self, webhook_proxy, id_converter, get_webhook, has_role, identity_enforceable):
+    async def test_webhook_called_with_appropriate_message(self, webhook_proxy, id_converter, get_webhook, has_role, identity_enforceable, generate_battery_message):
         '''
         should call proxy_message_by_webhook an amount of times equal to unique drones specified. Each message should be prepended with each drones ID.
         '''
         amplification_cog = amplify.AmplificationCog()
 
         drone = AsyncMock()
-        drone.avatar.url = "Pretty avatar"
-        drone.display_name = "5890"
+        drone.display_avatar.url = "Pretty avatar"
+        drone.display_name = "3287"
         id_converter.return_value = set(drone)
 
         webhook = AsyncMock()
@@ -34,13 +35,17 @@ class TestAmplify(unittest.IsolatedAsyncioTestCase):
         message = "Beep boop!"
         target_channel = AsyncMock()
 
+        generate_battery_message.return_value = "3287 :: Beep boop!"
+
         await amplification_cog.amplify(amplification_cog, context, message, target_channel)
         webhook_proxy.assert_called_once_with(
-            message_content="5890 :: Beep boop!",
-            message_username="5890",
+            message_content="3287 :: Beep boop!",
+            message_username="3287",
             message_avatar="Pretty avatar",
             webhook=webhook
         )
+
+        generate_battery_message.assert_called_once_with("3287 :: Beep boop!")
 
     @patch("ai.amplify.has_role")
     async def test_does_not_work_if_not_Mxtress(self, has_role):

--- a/test/test_battery.py
+++ b/test/test_battery.py
@@ -253,27 +253,24 @@ class TestBattery(unittest.IsolatedAsyncioTestCase):
 
         discord_get.side_effect = self.battery_emoji_getter
 
-        bot = Mock()
-        battery_cog = battery.BatteryCog(bot)
-
         battery_percentage.return_value = 100
         message_copy.content = original_message
-        await battery_cog.append_battery_indicator(message, message_copy)
+        battery.add_battery_indicator_to_copy(message, message_copy)
         self.assertEqual(message_copy.content, f"FULLBATTERYEMOJI :: {original_message}")
 
         battery_percentage.return_value = 50
         message_copy.content = original_message
-        await battery_cog.append_battery_indicator(message, message_copy)
+        battery.add_battery_indicator_to_copy(message, message_copy)
         self.assertEqual(message_copy.content, f"MIDBATTERYEMOJI :: {original_message}")
 
         battery_percentage.return_value = 20
         message_copy.content = original_message
-        await battery_cog.append_battery_indicator(message, message_copy)
+        battery.add_battery_indicator_to_copy(message, message_copy)
         self.assertEqual(message_copy.content, f"LOWBATTERYEMOJI :: {original_message}")
 
         battery_percentage.return_value = 5
         message_copy.content = original_message
-        await battery_cog.append_battery_indicator(message, message_copy)
+        battery.add_battery_indicator_to_copy(message, message_copy)
         self.assertEqual(message_copy.content, f"EMPTYBATTERYEMOJI :: {original_message}")
 
     @patch("ai.battery.get")
@@ -292,27 +289,24 @@ class TestBattery(unittest.IsolatedAsyncioTestCase):
 
         discord_get.side_effect = self.battery_emoji_getter
 
-        bot = Mock()
-        battery_cog = battery.BatteryCog(bot)
-
         battery_percentage.return_value = 100
         message_copy.content = original_message
-        await battery_cog.append_battery_indicator(message, message_copy)
+        battery.add_battery_indicator_to_copy(message, message_copy)
         self.assertEqual(message_copy.content, "5890 :: FULLBATTERYEMOJI :: Hello.\nBeep boop.")
 
         battery_percentage.return_value = 50
         message_copy.content = original_message
-        await battery_cog.append_battery_indicator(message, message_copy)
+        battery.add_battery_indicator_to_copy(message, message_copy)
         self.assertEqual(message_copy.content, "5890 :: MIDBATTERYEMOJI :: Hello.\nBeep boop.")
 
         battery_percentage.return_value = 20
         message_copy.content = original_message
-        await battery_cog.append_battery_indicator(message, message_copy)
+        battery.add_battery_indicator_to_copy(message, message_copy)
         self.assertEqual(message_copy.content, "5890 :: LOWBATTERYEMOJI :: Hello.\nBeep boop.")
 
         battery_percentage.return_value = 5
         message_copy.content = original_message
-        await battery_cog.append_battery_indicator(message, message_copy)
+        battery.add_battery_indicator_to_copy(message, message_copy)
         self.assertEqual(message_copy.content, "5890 :: EMPTYBATTERYEMOJI :: Hello.\nBeep boop.")
 
     @patch("ai.battery.is_drone", return_value=True)

--- a/test/test_battery.py
+++ b/test/test_battery.py
@@ -255,22 +255,22 @@ class TestBattery(unittest.IsolatedAsyncioTestCase):
 
         battery_percentage.return_value = 100
         message_copy.content = original_message
-        battery.add_battery_indicator_to_copy(message, message_copy)
+        await battery.add_battery_indicator_to_copy(message, message_copy)
         self.assertEqual(message_copy.content, f"FULLBATTERYEMOJI :: {original_message}")
 
         battery_percentage.return_value = 50
         message_copy.content = original_message
-        battery.add_battery_indicator_to_copy(message, message_copy)
+        await battery.add_battery_indicator_to_copy(message, message_copy)
         self.assertEqual(message_copy.content, f"MIDBATTERYEMOJI :: {original_message}")
 
         battery_percentage.return_value = 20
         message_copy.content = original_message
-        battery.add_battery_indicator_to_copy(message, message_copy)
+        await battery.add_battery_indicator_to_copy(message, message_copy)
         self.assertEqual(message_copy.content, f"LOWBATTERYEMOJI :: {original_message}")
 
         battery_percentage.return_value = 5
         message_copy.content = original_message
-        battery.add_battery_indicator_to_copy(message, message_copy)
+        await battery.add_battery_indicator_to_copy(message, message_copy)
         self.assertEqual(message_copy.content, f"EMPTYBATTERYEMOJI :: {original_message}")
 
     @patch("ai.battery.get")
@@ -291,22 +291,22 @@ class TestBattery(unittest.IsolatedAsyncioTestCase):
 
         battery_percentage.return_value = 100
         message_copy.content = original_message
-        battery.add_battery_indicator_to_copy(message, message_copy)
+        await battery.add_battery_indicator_to_copy(message, message_copy)
         self.assertEqual(message_copy.content, "5890 :: FULLBATTERYEMOJI :: Hello.\nBeep boop.")
 
         battery_percentage.return_value = 50
         message_copy.content = original_message
-        battery.add_battery_indicator_to_copy(message, message_copy)
+        await battery.add_battery_indicator_to_copy(message, message_copy)
         self.assertEqual(message_copy.content, "5890 :: MIDBATTERYEMOJI :: Hello.\nBeep boop.")
 
         battery_percentage.return_value = 20
         message_copy.content = original_message
-        battery.add_battery_indicator_to_copy(message, message_copy)
+        await battery.add_battery_indicator_to_copy(message, message_copy)
         self.assertEqual(message_copy.content, "5890 :: LOWBATTERYEMOJI :: Hello.\nBeep boop.")
 
         battery_percentage.return_value = 5
         message_copy.content = original_message
-        battery.add_battery_indicator_to_copy(message, message_copy)
+        await battery.add_battery_indicator_to_copy(message, message_copy)
         self.assertEqual(message_copy.content, "5890 :: EMPTYBATTERYEMOJI :: Hello.\nBeep boop.")
 
     @patch("ai.battery.is_drone", return_value=True)


### PR DESCRIPTION
Using the correct avatar was trivial but in order to add the battery indicator I wanted to reuse the existing code in the battery module. That required some refactoring though. I am quite happy with that as the functions I reused are now smaller and easier use in other contexts as well as unit test.

closes #386 