### PR TITLE
require confirmation for addition of trusted users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ ai.db-journal
 
 # Other misc config files
 .python-version
+.DS_Store

--- a/ai/trusted_user.py
+++ b/ai/trusted_user.py
@@ -38,23 +38,23 @@ async def add_trusted_user(context, trusted_user_name: str):
     trusted_user = find_user_by_display_name_or_drone_id(trusted_user_name, context.bot.guilds[0])
 
     if trusted_user is None:
-        await context.send(f"No user with name \"{trusted_user_name}\" found")
+        await context.send(f"No user with name \"{trusted_user_name}\" found.")
         return
 
     if trusted_user.id == context.author.id:
-        await context.send("Can not add yourself to your list of trusted users")
+        await context.send("Can not add yourself to your list of trusted users.")
         return
 
     trusted_users = get_trusted_users(context.author.id)
 
     if trusted_user.id in trusted_users:
-        await context.send(f"User with name \"{trusted_user_name}\" is already trusted")
+        await context.send(f"User with name \"{trusted_user_name}\" is already trusted.")
         return
 
     # report back to drone
     trusted_users.append(trusted_user.id)
     set_trusted_users(context.author.id, trusted_users)
-    await context.send(f"Successfully added trusted user \"{trusted_user_name}\"")
+    await context.send(f"Successfully added trusted user \"{trusted_user_name}\".")
 
     # notify trusted user
     drone_name = context.bot.guilds[0].get_member(context.author.id).display_name
@@ -65,22 +65,22 @@ async def remove_trusted_user(context, trusted_user_name: str):
     trusted_user = find_user_by_display_name_or_drone_id(trusted_user_name, context.bot.guilds[0])
 
     if trusted_user is None:
-        await context.send(f"No user with name \"{trusted_user_name}\" found")
+        await context.send(f"No user with name \"{trusted_user_name}\" found.")
         return
 
     trusted_users = get_trusted_users(context.author.id)
 
     if str(trusted_user.id) == HIVE_MXTRESS_USER_ID:
-        await context.send("Can not remove the Hive Mxtress as a trusted user")
+        await context.send("Can not remove the Hive Mxtress as a trusted user.")
         return
 
     if trusted_user.id not in trusted_users:
-        await context.send(f"User with name \"{trusted_user_name}\" was not trusted")
+        await context.send(f"User with name \"{trusted_user_name}\" was not trusted.")
         return
 
     trusted_users.remove(trusted_user.id)
     set_trusted_users(context.author.id, trusted_users)
-    await context.send(f"Successfully removed trusted user \"{trusted_user_name}\"")
+    await context.send(f"Successfully removed trusted user \"{trusted_user_name}\".")
 
 
 def find_user_by_display_name_or_drone_id(id: str, guild: discord.Guild) -> discord.Member:

--- a/ai/trusted_user.py
+++ b/ai/trusted_user.py
@@ -17,10 +17,10 @@ REQUEST_TIMEOUT = timedelta(hours=24)
 
 class TrustedUserRequest:
 
-    def __init__(self, target: discord.Member, issuer: discord.Member, question_message: discord.Message):
+    def __init__(self, target: discord.Member, issuer: discord.Member, question_message_id: int):
         self.target = target
         self.issuer = issuer
-        self.question_message = question_message
+        self.question_message_id = question_message_id
         self.issued = datetime.now()
 
 
@@ -64,7 +64,8 @@ class TrustedUserCog(Cog):
         # request permission from trusted user and notify drone
         drone_name = context.bot.guilds[0].get_member(context.author.id).display_name
         question_message = await trusted_user.send(f"\"{drone_name}\" is requesting to add you as a trusted user. This request will expire in 24 hours. To accept or reject this request, reply to this message. (y/n)")
-        request = TrustedUserRequest(trusted_user, context.author, question_message)
+        question_message_id = int(question_message.id)
+        request = TrustedUserRequest(trusted_user, context.author, question_message_id)
         LOGGER.info(f"Adding a new trusted user addition request: {request}")
         self.trusted_user_requests.append(request)
         await context.reply(f"Request sent to \"{trusted_user.display_name}\". They have 24 hours to accept.")
@@ -87,7 +88,7 @@ class TrustedUserCog(Cog):
                 matching_request = request
                 break
 
-        if matching_request and message.reference and message.reference.resolved == matching_request.question_message:
+        if matching_request and message.reference.message_id and message.reference.resolved.id == matching_request.question_message_id:
             LOGGER.info(f"Message detected as response to a trusted user addition request {matching_request}")
 
             # fetch display names of parties involved

--- a/ai/trusted_user.py
+++ b/ai/trusted_user.py
@@ -1,27 +1,73 @@
 import logging
+from datetime import datetime, timedelta
+from typing import List
 
-from discord.utils import get
 import discord
 from discord.ext.commands import Cog, command, dm_only
+from discord.ext import tasks
+from discord.utils import get
 
 from bot_utils import COMMAND_PREFIX
 from db.drone_dao import get_trusted_users, set_trusted_users, get_discord_id_of_drone, fetch_all_drones_with_trusted_user, parse_trusted_users_text
 from resources import BRIEF_DM_ONLY, BRIEF_DRONE_OS, HIVE_MXTRESS_USER_ID
 
 LOGGER = logging.getLogger('ai')
+REQUEST_TIMEOUT = timedelta(hours=24)
+
+
+class TrustedUserRequest:
+
+    def __init__(self, target: discord.Member, issuer: discord.Member, question_message: discord.Message):
+        self.target = target
+        self.issuer = issuer
+        self.question_message = question_message
+        self.issued = datetime.now()
 
 
 class TrustedUserCog(Cog):
 
+    trusted_user_requests: List[TrustedUserRequest] = []
+
+    def __init__(self, bot):
+        self.bot = bot
+
+    @tasks.loop(hours=1)
+    async def clean_trusted_user_requests(self):
+        now = datetime.now()
+        self.trusted_user_requests = list(filter(lambda request: request.issued + REQUEST_TIMEOUT > now, self.trusted_user_requests))
+
     @dm_only()
     @command(usage=f"{COMMAND_PREFIX}add_trusted_user \"A trusted user\"", brief=[BRIEF_DRONE_OS, BRIEF_DM_ONLY])
-    async def add_trusted_user(self, context, user_name: str):
+    async def add_trusted_user(self, context, trusted_user_name: str):
         '''
         Add user with the given nickname as a trusted user.
+        Requires trusted user to consent within 24 hours before addition.
         Use quotation marks if the username contains spaces.
         This command is used in DMs with the AI.
         '''
-        await add_trusted_user(context, user_name)
+        trusted_user = find_user_by_display_name_or_drone_id(trusted_user_name, context.bot.guilds[0])
+
+        if trusted_user is None:
+            await context.reply(f"No user with name \"{trusted_user_name}\" found.")
+            return
+
+        if trusted_user.id == context.author.id:
+            await context.reply("Can not add yourself to your list of trusted users.")
+            return
+
+        trusted_users = get_trusted_users(context.author.id)
+
+        if trusted_user.id in trusted_users:
+            await context.reply(f"User with name \"{trusted_user_name}\" is already trusted.")
+            return
+
+        # request permission from trusted user and notify drone
+        drone_name = context.bot.guilds[0].get_member(context.author.id).display_name
+        question_message = await trusted_user.send(f"\"{drone_name}\" is requesting to add you as a trusted user. This request will expire in 24 hours. Do you accept? (y/n)")
+        request = TrustedUserRequest(trusted_user, context.author, question_message)
+        LOGGER.info(f"Adding a new trusted user addition request: {request}")
+        self.trusted_user_requests.append(request)
+        await context.reply(f"Request sent to \"{trusted_user_name}\". They have 24 hours to accept.")
 
     @dm_only()
     @command(usage=f"{COMMAND_PREFIX}remove_trusted_user \"The untrusted user\"", brief=[BRIEF_DRONE_OS, BRIEF_DM_ONLY])
@@ -33,54 +79,69 @@ class TrustedUserCog(Cog):
         '''
         await remove_trusted_user(context, user_name)
 
+    @dm_only()
+    async def trusted_user_response(self, message: discord.Message, message_copy=None):
+        matching_request = None
+        for request in self.trusted_user_requests:
+            if request.target == message.author:
+                matching_request = request
+                break
 
-async def add_trusted_user(context, trusted_user_name: str):
-    trusted_user = find_user_by_display_name_or_drone_id(trusted_user_name, context.bot.guilds[0])
+        if matching_request and message.reference and message.reference.resolved == matching_request.question_message:
+            LOGGER.info(f"Message detected as response to a trusted user addition request {matching_request}")
 
-    if trusted_user is None:
-        await context.send(f"No user with name \"{trusted_user_name}\" found.")
-        return
+            # fetch display names of parties involved
+            drone_name = request.issuer.display_name
+            trusted_user_name = request.target.display_name
 
-    if trusted_user.id == context.author.id:
-        await context.send("Can not add yourself to your list of trusted users.")
-        return
+            # if accepted, start addition and notification process
+            if message.content.lower() == "y".lower():
+                LOGGER.info("Consent given for trusted user addition. Writing to DB...")
 
-    trusted_users = get_trusted_users(context.author.id)
+                # get trusted user list and append new trusted user
+                trusted_users = get_trusted_users(request.issuer.id)
+                trusted_users.append(request.target.id)
+                set_trusted_users(request.issuer.id, trusted_users)
 
-    if trusted_user.id in trusted_users:
-        await context.send(f"User with name \"{trusted_user_name}\" is already trusted.")
-        return
+                # notify user and drone of successful addition
+                await message.reply(f"Consent noted. You have been added as a trusted user of \"{drone_name}\".")
+                await request.issuer.send(f"\"{trusted_user_name}\" has accepted your request and is now a trusted user.")
 
-    # report back to drone
-    trusted_users.append(trusted_user.id)
-    set_trusted_users(context.author.id, trusted_users)
-    await context.send(f"Successfully added trusted user \"{trusted_user_name}\".")
+                # remove request
+                self.trusted_user_requests.remove(matching_request)
 
-    # notify trusted user
-    drone_name = context.bot.guilds[0].get_member(context.author.id).display_name
-    await trusted_user.send(f"You were added as a trusted user by \"{drone_name}\".\nIf you believe this to be a mistake contact the drone in question or the moderation team.")
+            # if rejected, discard request and notify parties involved
+            elif message.content.lower() == "n".lower():
+                LOGGER.info("Consent not given for trusted user addition. Removing the request.")
+
+                # notify user and drone of rejection
+                await message.reply(f"Consent not given. You have not been added as a trusted user of \"{drone_name}\".")
+                await request.issuer.send(f"\"{trusted_user_name}\" has rejected your request. No changes have been made.")
+
+                # discard request
+                self.trusted_user_requests.remove(matching_request)
 
 
 async def remove_trusted_user(context, trusted_user_name: str):
     trusted_user = find_user_by_display_name_or_drone_id(trusted_user_name, context.bot.guilds[0])
 
     if trusted_user is None:
-        await context.send(f"No user with name \"{trusted_user_name}\" found.")
+        await context.reply(f"No user with name \"{trusted_user_name}\" found.")
         return
 
     trusted_users = get_trusted_users(context.author.id)
 
     if str(trusted_user.id) == HIVE_MXTRESS_USER_ID:
-        await context.send("Can not remove the Hive Mxtress as a trusted user.")
+        await context.reply("Can not remove the Hive Mxtress as a trusted user.")
         return
 
     if trusted_user.id not in trusted_users:
-        await context.send(f"User with name \"{trusted_user_name}\" was not trusted.")
+        await context.reply(f"User with name \"{trusted_user_name}\" was not trusted.")
         return
 
     trusted_users.remove(trusted_user.id)
     set_trusted_users(context.author.id, trusted_users)
-    await context.send(f"Successfully removed trusted user \"{trusted_user_name}\".")
+    await context.reply(f"Successfully removed trusted user \"{trusted_user_name}\".")
 
 
 def find_user_by_display_name_or_drone_id(id: str, guild: discord.Guild) -> discord.Member:

--- a/ai/trusted_user.py
+++ b/ai/trusted_user.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import datetime, timedelta
-from typing import List
+from typing import List, Optional
 
 import discord
 from discord.ext.commands import Cog, command, dm_only
@@ -144,7 +144,7 @@ async def remove_trusted_user(context, trusted_user_name: str):
     await context.reply(f"Successfully removed trusted user \"{trusted_user.display_name}\".")
 
 
-def find_user_by_display_name_or_drone_id(id: str, guild: discord.Guild) -> discord.Member:
+def find_user_by_display_name_or_drone_id(id: str, guild: discord.Guild) -> Optional[discord.Member]:
     user = get(guild.members, display_name=id)
 
     if user is None:

--- a/ai/trusted_user.py
+++ b/ai/trusted_user.py
@@ -63,7 +63,7 @@ class TrustedUserCog(Cog):
 
         # request permission from trusted user and notify drone
         drone_name = context.bot.guilds[0].get_member(context.author.id).display_name
-        question_message = await trusted_user.send(f"\"{drone_name}\" is requesting to add you as a trusted user. This request will expire in 24 hours. Do you accept? (y/n)")
+        question_message = await trusted_user.send(f"\"{drone_name}\" is requesting to add you as a trusted user. This request will expire in 24 hours. To accept or reject this request, reply to this message. (y/n)")
         request = TrustedUserRequest(trusted_user, context.author, question_message)
         LOGGER.info(f"Adding a new trusted user addition request: {request}")
         self.trusted_user_requests.append(request)

--- a/ai/trusted_user.py
+++ b/ai/trusted_user.py
@@ -58,7 +58,7 @@ class TrustedUserCog(Cog):
         trusted_users = get_trusted_users(context.author.id)
 
         if trusted_user.id in trusted_users:
-            await context.reply(f"User with name \"{trusted_user_name}\" is already trusted.")
+            await context.reply(f"User with name \"{trusted_user.display_name}\" is already trusted.")
             return
 
         # request permission from trusted user and notify drone
@@ -67,7 +67,7 @@ class TrustedUserCog(Cog):
         request = TrustedUserRequest(trusted_user, context.author, question_message)
         LOGGER.info(f"Adding a new trusted user addition request: {request}")
         self.trusted_user_requests.append(request)
-        await context.reply(f"Request sent to \"{trusted_user_name}\". They have 24 hours to accept.")
+        await context.reply(f"Request sent to \"{trusted_user.display_name}\". They have 24 hours to accept.")
 
     @dm_only()
     @command(usage=f"{COMMAND_PREFIX}remove_trusted_user \"The untrusted user\"", brief=[BRIEF_DRONE_OS, BRIEF_DM_ONLY])
@@ -136,12 +136,12 @@ async def remove_trusted_user(context, trusted_user_name: str):
         return
 
     if trusted_user.id not in trusted_users:
-        await context.reply(f"User with name \"{trusted_user_name}\" was not trusted.")
+        await context.reply(f"User with name \"{trusted_user.display_name}\" was not trusted.")
         return
 
     trusted_users.remove(trusted_user.id)
     set_trusted_users(context.author.id, trusted_users)
-    await context.reply(f"Successfully removed trusted user \"{trusted_user_name}\".")
+    await context.reply(f"Successfully removed trusted user \"{trusted_user.display_name}\".")
 
 
 def find_user_by_display_name_or_drone_id(id: str, guild: discord.Guild) -> discord.Member:

--- a/main.py
+++ b/main.py
@@ -1,48 +1,57 @@
 # Core
-import discord
-import sys
-import logging
-from logging import handlers
-from discord.ext.commands import Bot, MissingRequiredArgument
-from discord.ext.commands.errors import PrivateMessageOnly
-from traceback import TracebackException
-from datetime import datetime, timedelta
 import asyncio
 
+from datetime import datetime, timedelta
+
+import discord
+from discord.ext.commands import Bot, MissingRequiredArgument
+from discord.ext.commands.errors import PrivateMessageOnly
+
+import logging
+from logging import handlers
+
+import sys
+
+from traceback import TracebackException
+
+
 # Modules
-import ai.stoplights as stoplights
+import ai.add_voice as add_voice
+import ai.amplify as amplify
+import ai.assign as assign
+import ai.battery as battery
+import ai.drone_configuration as drone_configuration
+import ai.drone_os_status as drone_os_status
+import ai.emote as emote
+import ai.forbidden_word as forbidden_word
+import ai.glitch_message as glitch_message
+import ai.id_prepending as id_prepending
 import ai.identity_enforcement as identity_enforcement
+import ai.join as join
+import ai.orders_reporting as orders_reporting
+import ai.react as react
+import ai.respond as respond
 import ai.speech_optimization as speech_optimization
 import ai.speech_optimization_enforcement as speech_optimization_enforcement
-import ai.id_prepending as id_prepending
-import ai.join as join
-import ai.respond as respond
-import ai.storage as storage
-import ai.timers as timers
-import ai.emote as emote
-import ai.assign as assign
-import ai.orders_reporting as orders_reporting
 import ai.status as status
-import ai.drone_configuration as drone_configuration
-import ai.add_voice as add_voice
-import ai.trusted_user as trusted_user
-import ai.drone_os_status as drone_os_status
-import ai.glitch_message as glitch_message
-import ai.battery as battery
 import ai.status_message as status_message
-import ai.forbidden_word as forbidden_word
-import ai.react as react
-import ai.amplify as amplify
+import ai.stoplights as stoplights
+import ai.storage as storage
 import ai.temporary_dronification as temporary_dronification
+import ai.timers as timers
+import ai.trusted_user as trusted_user
 import webhook
+
 # Utils
 from bot_utils import COMMAND_PREFIX
 
 # Database
 from db import database
 from db import drone_dao
+
 # Constants
 from resources import DRONE_AVATAR, HIVE_MXTRESS_AVATAR, HEXCORP_AVATAR, BRIEF_DM_ONLY, BRIEF_HIVE_MXTRESS, BRIEF_DRONE_OS
+
 # Data objects
 from ai.data_objects import MessageCopy
 
@@ -98,19 +107,19 @@ bot.add_cog(trusted_user_cog)
 
 # Register message listeners.
 message_listeners = [
-    assign.check_for_assignment_message,
-    battery_cog.append_battery_indicator,
-    battery_cog.start_battery_drain,
-    forbidden_word.deny_thoughts,
-    glitch_message.glitch_if_applicable,
-    id_prepending.check_if_prepending_necessary,
-    identity_enforcement.enforce_identity,
     join.check_for_consent,
-    react.parse_for_reactions,
-    respond.respond_to_question,
-    speech_optimization.optimize_speech,
-    speech_optimization_enforcement.enforce_speech_optimization,
+    assign.check_for_assignment_message,
     stoplights.check_for_stoplights,
+    battery_cog.start_battery_drain,
+    id_prepending.check_if_prepending_necessary,
+    speech_optimization_enforcement.enforce_speech_optimization,
+    speech_optimization.optimize_speech,
+    identity_enforcement.enforce_identity,
+    forbidden_word.deny_thoughts,
+    battery_cog.append_battery_indicator,
+    react.parse_for_reactions,
+    glitch_message.glitch_if_applicable,
+    respond.respond_to_question,
     storage.store_drone,
     temporary_dronification_cog.temporary_dronification_response
 ]
@@ -122,12 +131,12 @@ bot_message_listeners = []
 direct_message_listeners = [trusted_user_cog.trusted_user_response]
 
 # Cogs that do not use tasks.
-bot.add_cog(emote.EmoteCog())
-bot.add_cog(drone_configuration.DroneConfigurationCog())
 bot.add_cog(add_voice.AddVoiceCog(bot))
-bot.add_cog(drone_os_status.DroneOsStatusCog())
-bot.add_cog(status.StatusCog(message_listeners))
 bot.add_cog(amplify.AmplificationCog())
+bot.add_cog(drone_configuration.DroneConfigurationCog())
+bot.add_cog(drone_os_status.DroneOsStatusCog())
+bot.add_cog(emote.EmoteCog())
+bot.add_cog(status.StatusCog(message_listeners))
 
 
 # Categorize which tasks run at which intervals

--- a/main.py
+++ b/main.py
@@ -78,56 +78,69 @@ bot.remove_command("help")
 
 
 # Need to create cogs as a seperate variable so they can be assigned and have their tasks started after bot has booted.
+battery_cog = battery.BatteryCog(bot)
+forbidden_word_cog = forbidden_word.ForbiddenWordCog(bot)
+orders_reporting_cog = orders_reporting.OrderReportingCog(bot)
 status_message_cog = status_message.StatusMessageCog(bot)
 storage_cog = storage.StorageCog(bot)
-orders_reporting_cog = orders_reporting.OrderReportingCog(bot)
-timers_cog = timers.TimersCog(bot)
-battery_cog = battery.BatteryCog(bot)
 temporary_dronification_cog = temporary_dronification.TemporaryDronificationCog(bot)
-forbidden_word_cog = forbidden_word.ForbiddenWordCog(bot)
+timers_cog = timers.TimersCog(bot)
+trusted_user_cog = trusted_user.TrustedUserCog(bot)
 
+bot.add_cog(battery_cog)
+bot.add_cog(forbidden_word_cog)
+bot.add_cog(orders_reporting_cog)
 bot.add_cog(status_message_cog)
 bot.add_cog(storage_cog)
-bot.add_cog(orders_reporting_cog)
+bot.add_cog(temporary_dronification_cog)
 bot.add_cog(timers_cog)
 bot.add_cog(battery_cog)
 bot.add_cog(forbidden_word_cog)
 
 # Register message listeners.
 message_listeners = [
-    join.check_for_consent,
     assign.check_for_assignment_message,
-    stoplights.check_for_stoplights,
-    battery_cog.start_battery_drain,
-    id_prepending.check_if_prepending_necessary,
-    speech_optimization_enforcement.enforce_speech_optimization,
-    speech_optimization.optimize_speech,
-    identity_enforcement.enforce_identity,
-    forbidden_word.deny_thoughts,
     battery_cog.append_battery_indicator,
-    react.parse_for_reactions,
+    battery_cog.start_battery_drain,
+    forbidden_word.deny_thoughts,
     glitch_message.glitch_if_applicable,
+    id_prepending.check_if_prepending_necessary,
+    identity_enforcement.enforce_identity,
+    join.check_for_consent,
+    react.parse_for_reactions,
     respond.respond_to_question,
+    speech_optimization.optimize_speech,
+    speech_optimization_enforcement.enforce_speech_optimization,
+    stoplights.check_for_stoplights,
     storage.store_drone,
     temporary_dronification_cog.temporary_dronification_response
 ]
 
-# register message listeners that take messages sent by bots
+# Register message listeners that take messages sent by bots
 bot_message_listeners = []
 
 # Cogs that do not use tasks.
 bot.add_cog(emote.EmoteCog())
 bot.add_cog(drone_configuration.DroneConfigurationCog())
 bot.add_cog(add_voice.AddVoiceCog(bot))
-bot.add_cog(trusted_user.TrustedUserCog())
 bot.add_cog(drone_os_status.DroneOsStatusCog())
 bot.add_cog(status.StatusCog(message_listeners))
 bot.add_cog(amplify.AmplificationCog())
-bot.add_cog(temporary_dronification_cog)
+
 
 # Categorize which tasks run at which intervals
-minute_tasks = [storage_cog.release_timed, battery_cog.track_active_battery_drain, battery_cog.track_drained_batteries, battery_cog.warn_low_battery_drones, temporary_dronification_cog.clean_dronification_requests, temporary_dronification_cog.release_temporary_drones, timers_cog.process_timers]
-hour_tasks = [storage_cog.report_storage, orders_reporting_cog.deactivate_drones_with_completed_orders]
+minute_tasks = [
+    battery_cog.track_active_battery_drain,
+    battery_cog.track_drained_batteries,
+    battery_cog.warn_low_battery_drones,
+    storage_cog.release_timed,
+    temporary_dronification_cog.clean_dronification_requests,
+    temporary_dronification_cog.release_temporary_drones,
+    timers_cog.process_timers]
+hour_tasks = [
+    orders_reporting_cog.deactivate_drones_with_completed_orders,
+    storage_cog.report_storage,
+    trusted_user_cog.clean_trusted_user_requests]
 timing_agnostic_tasks = [status_message_cog.change_status]
 
 

--- a/test/test_trusted_user.py
+++ b/test/test_trusted_user.py
@@ -274,7 +274,7 @@ class TrustedUserTest(unittest.IsolatedAsyncioTestCase):
 
         # assert
         set_trusted_users.assert_not_called()
-        self.context.reply.assert_called_once_with(f"No user with name \"0000\" found.")
+        self.context.reply.assert_called_once_with("No user with name \"0000\" found.")
 
     @patch("ai.trusted_user.get_discord_id_of_drone")
     @patch("ai.trusted_user.get_trusted_users")

--- a/test/test_trusted_user.py
+++ b/test/test_trusted_user.py
@@ -70,6 +70,8 @@ class TrustedUserTest(unittest.IsolatedAsyncioTestCase):
         get_trusted_users.return_value = [int(self.hive_mxtress.id)]
 
         question_message = AsyncMock()
+        question_message.id = 123456
+        question_message_id = question_message.id
         self.trusted_user_member.send.return_value = question_message
         self.context.author = self.drone_member
 
@@ -82,7 +84,7 @@ class TrustedUserTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(1, len(self.cog.trusted_user_requests))
         self.assertEqual(self.trusted_user_member, self.cog.trusted_user_requests[0].target)
         self.assertEqual(self.drone_member, self.cog.trusted_user_requests[0].issuer)
-        self.assertEqual(question_message, self.cog.trusted_user_requests[0].question_message)
+        self.assertEqual(question_message_id, self.cog.trusted_user_requests[0].question_message_id)
 
     @patch("ai.trusted_user.get_trusted_users")
     @patch("ai.trusted_user.find_user_by_display_name_or_drone_id")
@@ -135,18 +137,19 @@ class TrustedUserTest(unittest.IsolatedAsyncioTestCase):
     @patch("ai.trusted_user.get_trusted_users")
     async def test_trusted_user_response_accepted(self, get_trusted_users, set_trusted_users):
         # setup
-        question_message = AsyncMock()
+        question_message_id = AsyncMock()
 
         target = self.trusted_user_member
         issuer = self.drone_member
 
-        request = TrustedUserRequest(target, issuer, question_message)
+        request = TrustedUserRequest(target, issuer, question_message_id)
 
         self.cog.trusted_user_requests.append(request)
 
         message = AsyncMock()
         message.content = "y"
-        message.reference.resolved = question_message
+        message.reference.message.id = question_message_id
+        message.reference.resolved.id = question_message_id
         message.author = target
         message.guild = AsyncMock()
 
@@ -164,18 +167,19 @@ class TrustedUserTest(unittest.IsolatedAsyncioTestCase):
     @patch("ai.trusted_user.get_trusted_users")
     async def test_trusted_user_response_rejected(self, get_trusted_users, set_trusted_users):
         # setup
-        question_message = AsyncMock()
+        question_message_id = AsyncMock()
 
         target = self.trusted_user_member
         issuer = self.drone_member
 
-        request = TrustedUserRequest(target, issuer, question_message)
+        request = TrustedUserRequest(target, issuer, question_message_id)
 
         self.cog.trusted_user_requests.append(request)
 
         message = AsyncMock()
         message.content = "n"
-        message.reference.resolved = question_message
+        message.reference.message_id = question_message_id
+        message.reference.resolved.id = question_message_id
         message.author = target
         message.guild = AsyncMock()
 
@@ -193,18 +197,19 @@ class TrustedUserTest(unittest.IsolatedAsyncioTestCase):
     @patch("ai.trusted_user.get_trusted_users")
     async def test_trusted_user_response_invalid(self, get_trusted_users, set_trusted_users):
         # setup
-        question_message = AsyncMock()
+        question_message_id = AsyncMock()
 
         target = self.trusted_user_member
         issuer = self.drone_member
 
-        request = TrustedUserRequest(target, issuer, question_message)
+        request = TrustedUserRequest(target, issuer, question_message_id)
 
         self.cog.trusted_user_requests.append(request)
 
         message = AsyncMock()
         message.content = "bingle"
-        message.reference.resolved = question_message
+        message.reference.message_id = question_message_id
+        message.reference.resolved.id = question_message_id
         message.author = target
         message.guild = AsyncMock()
 

--- a/test/test_trusted_user.py
+++ b/test/test_trusted_user.py
@@ -1,10 +1,15 @@
+'''
 import unittest
+from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, patch, Mock
-from ai.trusted_user import add_trusted_user, remove_trusted_user, remove_trusted_user_on_all
+from ai.trusted_user import TrustedUserCog, TrustedUserRequest, find_user_by_display_name_or_drone_id, remove_trusted_user, remove_trusted_user_on_all
 from resources import HIVE_MXTRESS_USER_ID
 
 
 class TrustedUserTest(unittest.IsolatedAsyncioTestCase):
+
+    bot = AsyncMock()
+    cog = TrustedUserCog(bot)
 
     def setUp(self):
         self.hive_mxtress = AsyncMock()
@@ -87,6 +92,7 @@ class TrustedUserTest(unittest.IsolatedAsyncioTestCase):
         # assert
         set_trusted_users.assert_not_called()
         self.context.send.assert_called_once_with("No user with name \"Some random name\" found")
+
 
     @patch("ai.trusted_user.get_discord_id_of_drone")
     @patch("ai.trusted_user.get_trusted_users")
@@ -178,3 +184,4 @@ class TrustedUserTest(unittest.IsolatedAsyncioTestCase):
         # assert
         fetch_all_drones_with_trusted_user.assert_called_once_with(id_of_member_leaving)
         set_trusted_users.assert_called_once_with(drone.id, [int(HIVE_MXTRESS_USER_ID), unrelated_user_id])
+'''


### PR DESCRIPTION
Assigning a trusted user now requires consent from the assignee, before they're actually added as a trusted user. Drone is notified when the user accepts or rejects the request. Requests currently expire in 24 hours from assignment, but this can be changed easily if required. Current behaviour regarding removing trusted users is untouched - no verification required and no notification is sent.

closes #275.