### PR TITLE
adding validator to check if initiator is found in DB

### DIFF
--- a/src/ai/storage.py
+++ b/src/ai/storage.py
@@ -131,6 +131,11 @@ async def store_drone(message: discord.Message, message_copy=None):
     # find initiator
     initiator = fetch_drone_with_drone_id(drone_id)
 
+    # check if initiator evaluates to a valid drone. special case if it's the Hive Mxtress.
+    if (not (drone_id == '0006' and roles.has_role(message.author, roles.HIVE_MXTRESS))) and (initiator is None):
+        await message.channel.send(f'Initiator drone with ID {drone_id} could not be found.')
+        return False
+
     # validate specified initiator is message sender
     if (not (drone_id == '0006' and roles.has_role(message.author, roles.HIVE_MXTRESS))) and (message.author.id != initiator.id):  # temp fix while we decide what to do with the db missing a drone entry for the Hive Mxtress
         await message.channel.send(f'You are not {drone_id}. Yes, we can indeed tell identical faceless drones apart from each other.')
@@ -139,9 +144,9 @@ async def store_drone(message: discord.Message, message_copy=None):
     # find target drone
     drone_to_store = fetch_drone_with_drone_id(target_id)
 
-    # if no drone was stored answer with error
+    # check if target evaluates to a valid drone
     if drone_to_store is None:
-        await message.channel.send(f'Drone with ID {target_id} could not be found.')
+        await message.channel.send(f'Target drone with ID {target_id} could not be found.')
         return False
 
     if is_free_storage(drone_to_store):

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -104,6 +104,22 @@ class StorageTest(unittest.IsolatedAsyncioTestCase):
         fetch_storage_by_target_id.assert_called_once_with('0006')
         message.channel.send.assert_called_once_with("You cannot store the Hive Mxtress, silly drone.")
 
+    @patch("src.ai.storage.fetch_drone_with_drone_id", return_value=None)
+    @patch("src.ai.storage.fetch_storage_by_target_id", return_value=None)
+    async def test_store_initiator_not_found(self, fetch_storage_by_target_id, fetch_drone_with_drone_id):
+        # setup
+        message = AsyncMock()
+        message.channel.name = channels.STORAGE_FACILITY
+        message.content = "3288 :: 3287 :: 1 :: who's this drone?"
+        message.author.roles = [drone_role]
+        message.author.id = "3287snowflake"
+
+        # run & assert
+        self.assertFalse(await storage.store_drone(message))
+        fetch_storage_by_target_id.assert_called_once_with('3287')
+        fetch_drone_with_drone_id.assert_called_once_with('3288')
+        message.channel.send.assert_called_once_with("Initiator drone with ID 3288 could not be found.")
+
     @patch("src.ai.storage.fetch_drone_with_drone_id")
     @patch("src.ai.storage.fetch_storage_by_target_id", return_value=None)
     async def test_store_drone_is_forged(self, fetch_storage_by_target_id, fetch_drone_with_drone_id):
@@ -136,7 +152,7 @@ class StorageTest(unittest.IsolatedAsyncioTestCase):
         # run & assert
         self.assertFalse(await storage.store_drone(message))
         fetch_storage_by_target_id.assert_called_once_with('3288')
-        message.channel.send.assert_called_once_with("Drone with ID 3288 could not be found.")
+        message.channel.send.assert_called_once_with("Target drone with ID 3288 could not be found.")
 
     @patch("src.ai.storage.is_free_storage", return_value=True)
     @patch("src.ai.storage.datetime")


### PR DESCRIPTION
Added an additional validator to check if the initiator is found in the database, and send an error message if it isn't. Includes special case handling for the Hive Mxtress.

closes #414 