### PR TITLE
Allow the whole test suite to run

### DIFF
--- a/test/test_temporary_dronification.py
+++ b/test/test_temporary_dronification.py
@@ -8,7 +8,9 @@ from src.roles import HIVE_MXTRESS
 class TestSpeechOptimization(unittest.IsolatedAsyncioTestCase):
 
     bot = AsyncMock()
+    bot.add_command = Mock()
     cog = TemporaryDronificationCog(bot)
+    cog = cog._inject(bot)
 
     def setUp(self):
         self.bot.reset_mock()
@@ -31,7 +33,7 @@ class TestSpeechOptimization(unittest.IsolatedAsyncioTestCase):
         is_drone.return_value = False
 
         # run
-        await self.cog.temporarily_dronify(self.cog, context, target, hours)
+        await self.cog.temporarily_dronify(context, target, hours)
 
         # assert
         is_drone.assert_called_once_with(target)
@@ -58,7 +60,7 @@ class TestSpeechOptimization(unittest.IsolatedAsyncioTestCase):
         is_drone.return_value = True
 
         # run
-        await self.cog.temporarily_dronify(self.cog, context, target, hours)
+        await self.cog.temporarily_dronify(context, target, hours)
 
         # assert
         is_drone.assert_called_once_with(target)
@@ -82,7 +84,7 @@ class TestSpeechOptimization(unittest.IsolatedAsyncioTestCase):
         hours = 4
         is_drone.return_value = False
         # run
-        await self.cog.temporarily_dronify(self.cog, context, target, hours)
+        await self.cog.temporarily_dronify(context, target, hours)
 
         # assert
         is_drone.assert_called_once_with(target)
@@ -105,7 +107,7 @@ class TestSpeechOptimization(unittest.IsolatedAsyncioTestCase):
         is_drone.return_value = False
 
         # run
-        await self.cog.temporarily_dronify(self.cog, context, target, hours)
+        await self.cog.temporarily_dronify(context, target, hours)
 
         # assert
         context.reply.assert_called_once_with("Hours must be greater than 0.")
@@ -128,7 +130,7 @@ class TestSpeechOptimization(unittest.IsolatedAsyncioTestCase):
         is_drone.return_value = False
 
         # run
-        await self.cog.temporarily_dronify(self.cog, context, target, hours)
+        await self.cog.temporarily_dronify(context, target, hours)
 
         # assert
         is_drone.assert_called_once_with(target)

--- a/test/test_trusted_user.py
+++ b/test/test_trusted_user.py
@@ -7,7 +7,9 @@ from src.resources import HIVE_MXTRESS_USER_ID
 class TrustedUserTest(unittest.IsolatedAsyncioTestCase):
 
     bot = AsyncMock()
+    bot.add_command = Mock()
     cog = TrustedUserCog(bot)
+    cog = cog._inject(bot)
 
     def setUp(self):
         self.hive_mxtress = AsyncMock()
@@ -76,7 +78,7 @@ class TrustedUserTest(unittest.IsolatedAsyncioTestCase):
         self.context.author = self.drone_member
 
         # run
-        await self.cog.add_trusted_user(self.cog, self.context, self.trusted_user_member.name)
+        await self.cog.add_trusted_user(self.context, self.trusted_user_member.name)
 
         # assert
         self.trusted_user_member.send.assert_called_once_with("\"⬡-Drone #3287\" is requesting to add you as a trusted user. This request will expire in 24 hours. To accept or reject this request, reply to this message. (y/n)")
@@ -94,7 +96,7 @@ class TrustedUserTest(unittest.IsolatedAsyncioTestCase):
         get_trusted_users.return_value = [self.hive_mxtress.id]
 
         # run
-        await self.cog.add_trusted_user(self.cog, self.context, self.trusted_user_member.name)
+        await self.cog.add_trusted_user(self.context, self.trusted_user_member.name)
 
         # assert
         self.context.reply.assert_called_once_with("No user with name \"Drone 9813\" found.")
@@ -110,7 +112,7 @@ class TrustedUserTest(unittest.IsolatedAsyncioTestCase):
         self.context.author = self.drone_member
 
         # run
-        await self.cog.add_trusted_user(self.cog, self.context, self.trusted_user_member.name)
+        await self.cog.add_trusted_user(self.context, self.trusted_user_member.name)
 
         # assert
         self.context.reply.assert_called_once_with("Can not add yourself to your list of trusted users.")
@@ -126,7 +128,7 @@ class TrustedUserTest(unittest.IsolatedAsyncioTestCase):
         self.context.author = self.drone_member
 
         # run
-        await self.cog.add_trusted_user(self.cog, self.context, self.trusted_user_member.name)
+        await self.cog.add_trusted_user(self.context, self.trusted_user_member.name)
 
         # assert
         self.context.reply.assert_called_once_with("User with name \"⬡-Drone #9813\" is already trusted.")
@@ -321,7 +323,7 @@ class TrustedUserTest(unittest.IsolatedAsyncioTestCase):
         # setup
 
         # run
-        await self.cog.remove_trusted_user(self.cog, self.context, self.trusted_user_member.name)
+        await self.cog.remove_trusted_user(self.context, self.trusted_user_member.name)
 
         # assert
         remove_trusted_user.assert_called_once()


### PR DESCRIPTION
This will allow the entire test suite to be run with `python -m unittest`, instead of having to run each file individually because of tests interfering with each other through global state.

The Cog class maintains a static list of commands, which it modifies when `bot.add_cog()` calls `cog._inject()`, which calls `command._set_cog()`.  The change here will ensure that `_set_cog()` is re-called on the commands, associating them with the cog being tested instead of the one created in `main.py` and loaded by `test_main.py`.

`bot.add_command()` is mocked separately because it is a synchronous function, and so will give a warning if mocked asynchronously.