### PR TITLE
Ignore code coverage HTML report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ ai.db-journal
 
 # Coverage data
 .coverage*
+htmlcov
 
 # Other misc config files
 .python-version


### PR DESCRIPTION
You can produce an easy to read unit test coverage report with `python -m coverage html`.
This PR is simply to have Git ignore the generated report.