### PR TITLE
Battery Types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,9 @@ htmlcov
 # Other misc config files
 .python-version
 .DS_Store
+
+# Unit testing temporary database
+test.db
+
+# Testing token file
+token.txt

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 import discord
 from discord.ext.commands import Bot, command as bot_command, MissingRequiredArgument
 from discord.ext.commands.errors import PrivateMessageOnly
-from src.bot_utils import connect
+from src.db.database import connect
 
 import logging
 from logging import handlers

--- a/main.py
+++ b/main.py
@@ -232,7 +232,7 @@ def ignore_self(func):
 async def on_message(message: discord.Message):
     # Don't ignore messages from the testing bot.
     # Usually process_commands() will ignore messages from bots.
-    if message.author.display_name == 'TestBot':
+    if message.author.name == 'TestBot':
         message.author.bot = False
 
     message_copy = MessageCopy(content=message.content, display_name=message.author.display_name, avatar=message.author.display_avatar, attachments=message.attachments, reactions=message.reactions)

--- a/res/db/migrate/0012_USER_ID.sql
+++ b/res/db/migrate/0012_USER_ID.sql
@@ -26,7 +26,8 @@ ALTER TABLE drone2 RENAME TO drone;
 
 CREATE TABLE storage2 (
     id VARCHAR(36) PRIMARY KEY,
-    stored_by INT UNSIGNED NOT NULL,
+    -- stored_by is nullable because the Hive Mxtress does not have a drone record.
+    stored_by INT UNSIGNED,
     target_id INT UNSIGNED NOT NULL,
     purpose VARCHAR(255) NOT NULL,
     roles TEXT NOT NULL,

--- a/res/db/migrate/0013_BATTERY_TYPES.sql
+++ b/res/db/migrate/0013_BATTERY_TYPES.sql
@@ -1,0 +1,60 @@
+-- Create a table to hold possible drone battery configurations.
+CREATE TABLE battery_types (
+    id INTEGER PRIMARY KEY,
+    name VARCHAR(64) NOT NULL,
+    capacity INT NOT NULL,
+    recharge_rate INT NOT NULL
+);
+
+-- Insert the standard battery types.
+INSERT INTO battery_types VALUES
+    (1, "Low", 240, 30),
+    (2, "Medium", 480, 120),
+    (3, "High", 720, 360);
+
+-- Recreate the drone table with the new column and foreign key constraint.
+CREATE TABLE drone2 (
+    discord_id UNSIGNED INT PRIMARY KEY,
+    drone_id CHAR(4) NOT NULL UNIQUE,
+    optimized BOOL NOT NULL DEFAULT 0,
+    glitched BOOL NOT NULL DEFAULT 0,
+    trusted_users TEXT NOT NULL DEFAULT "",
+    last_activity DATETIME,
+    id_prepending BOOL NOT NULL DEFAULT 0,
+    identity_enforcement BOOL NOT NULL DEFAULT 0,
+    can_self_configure BOOL NOT NULL DEFAULT 1,
+    temporary_until DATETIME,
+    is_battery_powered BOOL NOT NULL DEFAULT 0,
+    battery_type_id INT NOT NULL DEFAULT 2,
+    battery_minutes UNSIGNED INTEGER NOT NULL DEFAULT 480,
+    free_storage BOOL NOT NULL DEFAULT 0,
+    associate_name TEXT NOT NULL DEFAULT "",
+    FOREIGN KEY (battery_type_id) REFERENCES battery_types(id)
+);
+
+-- Patch up any NULL entries.
+UPDATE drone SET associate_name = drone_id WHERE associate_name IS NULL;
+
+-- Copy the drone records into the new table.
+INSERT INTO drone2
+    SELECT
+        discord_id,
+        drone_id,
+        optimized,
+        glitched,
+        trusted_users,
+        last_activity,
+        id_prepending,
+        identity_enforcement,
+        can_self_configure,
+        temporary_until,
+        is_battery_powered,
+        2,
+        battery_minutes,
+        free_storage,
+        associate_name
+    FROM drone;
+
+-- Delete the old drones table and rename the new one.
+DROP TABLE drone;
+ALTER TABLE drone2 RENAME TO drone;

--- a/src/ai/battery.py
+++ b/src/ai/battery.py
@@ -44,7 +44,7 @@ class BatteryCog(commands.Cog):
     async def set_battery_type(self, context, member: Union[Member, DroneMemberConverter], type_name: str):
         '''
         Hive Mxtress only command.
-        Recharges a drone to 100% battery.
+        Changes the drone's battery capacity and recharge rate.
         '''
 
         if not has_role(context.message.author, HIVE_MXTRESS):

--- a/src/ai/commands.py
+++ b/src/ai/commands.py
@@ -2,11 +2,9 @@ import discord
 from discord.ext.commands import BadArgument, Context, Converter
 
 from src.id_converter import convert_id_to_member
-from src.db.database import connect
 
 
 class DroneMemberConverter(Converter):
-    @connect()
     async def convert(self, context: Context, argument: str) -> discord.Member:
         '''
         Converts a given argument to a Member that is a drone. Raises BadArgument otherwise.

--- a/src/ai/drone_configuration.py
+++ b/src/ai/drone_configuration.py
@@ -185,9 +185,14 @@ async def rename_drone(context, old_id: str, new_id: str):
 async def unassign_drone(target: discord.Member):
     drone = await fetch_drone_with_id(target.id)
     guild = target.guild
+
     # check for existence
     if drone is None:
-        await target.send("You are not a drone. Can not unassign.")
+        try:
+            await target.send("You are not a drone. Can not unassign.")
+        except Exception:
+            # Sending will fail if target is a Discord bot.
+            pass
         return
 
     await target.edit(nick=drone.associate_name)
@@ -196,7 +201,12 @@ async def unassign_drone(target: discord.Member):
 
     # remove from DB
     await delete_drone_by_drone_id(drone.drone_id)
-    await target.send(f"Drone with ID {drone.drone_id} unassigned.")
+
+    try:
+        await target.send(f"Drone with ID {drone.drone_id} unassigned.")
+    except Exception:
+        # Sending will fail if target is a Discord bot.
+        pass
 
 
 async def emergency_release(context, drone_id: str):

--- a/src/ai/drone_configuration.py
+++ b/src/ai/drone_configuration.py
@@ -21,13 +21,13 @@ from src.db.drone_dao import (can_self_configure, delete_drone_by_drone_id,
                               is_glitched, is_identity_enforced, is_optimized,
                               is_prepending_id, rename_drone_in_db,
                               set_battery_minutes_remaining,
-                              update_droneOS_parameter)
+                              update_droneOS_parameter,
+                              get_battery_type)
 from src.db.timer_dao import (delete_timers_by_id_and_mode, insert_timer)
 from src.display_names import update_display_name
 from src.id_converter import convert_id_to_member
 from src.resources import (BRIEF_DM_ONLY, BRIEF_DRONE_OS, BRIEF_HIVE_MXTRESS,
-                           DRONE_AVATAR, HIVE_MXTRESS_USER_ID,
-                           MAX_BATTERY_CAPACITY_MINS)
+                           DRONE_AVATAR, HIVE_MXTRESS_USER_ID)
 from src.roles import (ADMIN, ASSOCIATE, BATTERY_DRAINED, BATTERY_POWERED,
                        DRONE, FREE_STORAGE, GLITCHED, HIVE_MXTRESS, ID_PREPENDING,
                        IDENTITY_ENFORCEMENT, MODERATION_ROLES,
@@ -156,7 +156,8 @@ class DroneConfigurationCog(Cog):
         # Additionally, reset the battery of any drone regardless of whether or not it's being toggled on or off.
         # And remove drained role if added.
         for drone in drones:
-            await set_battery_minutes_remaining(member=drone, minutes=MAX_BATTERY_CAPACITY_MINS)
+            battery_type = await get_battery_type(drone)
+            await set_battery_minutes_remaining(drone, battery_type.capacity)
             await drone.remove_roles(get(context.guild.roles, name=BATTERY_DRAINED))
 
 
@@ -262,20 +263,20 @@ async def toggle_parameter(context,
                 await set_can_self_configure(drone)
 
                 # remove any open timers for this mode
-                await delete_timers_by_id_and_mode(drone.discord_id, toggle_column)
+                await delete_timers_by_id_and_mode(drone.id, toggle_column)
 
             else:
                 await update_droneOS_parameter(drone, toggle_column, True)
                 await drone.add_roles(role)
                 message = toggle_on_message()
 
-                configured_by_self = (drone.discord_id == context.author.id)
+                configured_by_self = (drone.id == context.author.id)
                 await update_droneOS_parameter(drone, "can_self_configure", configured_by_self)
 
                 # create a new timer
                 if minutes > 0:
                     end_time = str(datetime.now() + timedelta(minutes=minutes))
-                    timer = Timer(str(uuid4()), drone.discord_id, toggle_column, end_time)
+                    timer = Timer(str(uuid4()), drone.id, toggle_column, end_time)
                     await insert_timer(timer)
                     message = toggle_on_timed_message(minutes)
                     LOGGER.info(f"Created a new config timer for {drone.display_name} toggling on {toggle_column} elapsing at {end_time}")
@@ -283,7 +284,7 @@ async def toggle_parameter(context,
             is_admin = has_role(drone, ADMIN)
             if await update_display_name(drone) and not is_admin:
                 # Display name has been updated, get the new drone object with updated display name.
-                drone = context.guild.get_member(drone.discord_id)
+                drone = context.guild.get_member(drone.id)
             await webhook.proxy_message_by_webhook(message_content=f'{get_id(drone.display_name)} :: {message}',
                                                    message_username=drone.display_name,
                                                    message_avatar=drone.display_avatar.url if not await identity_enforcable(drone, channel=context.channel) else DRONE_AVATAR,

--- a/src/ai/drone_os_status.py
+++ b/src/ai/drone_os_status.py
@@ -38,7 +38,6 @@ async def get_status(member: discord.Member, requesting_user: int, context) -> d
         .set_footer(text="HexCorp DroneOS")
 
     author = context.author if isinstance(context.author, discord.Member) else context.bot.guilds[0].get_member(context.author.id)
-    battery_type = await get_battery_type(member)
 
     trusted_users = await get_trusted_users(drone.discord_id)
     is_trusted_user = requesting_user in trusted_users
@@ -49,6 +48,8 @@ async def get_status(member: discord.Member, requesting_user: int, context) -> d
     if not is_trusted_user and not is_drone_self and not is_moderation:
         embed.description = "You are not registered as a trusted user of this drone."
         return embed
+
+    battery_type = await get_battery_type(member)
 
     # assemble description
     if is_trusted_user:

--- a/src/ai/storage.py
+++ b/src/ai/storage.py
@@ -66,8 +66,8 @@ class StorageCog(Cog):
             for stored in stored_drones:
                 # calculate remaining hours
                 remaining_hours = hours_from_now(datetime.fromisoformat(stored.release_time))
-                stored_drone = fetch_drone_with_id(stored.target_id)
-                initiator_drone = fetch_drone_with_id(stored.initiator_id)
+                initiator_drone = await fetch_drone_with_id(stored.stored_by)
+                stored_drone = await fetch_drone_with_id(stored.target_id)
 
                 if stored.stored_by is None:
                     await self.storage_channel.send(f'`Drone #{stored_drone.drone_id}`, stored away by the Hive Mxtress. Remaining time in storage: {round(remaining_hours, 2)} hours')

--- a/src/ai/storage.py
+++ b/src/ai/storage.py
@@ -16,8 +16,7 @@ from src.channels import STORAGE_CHAMBERS, STORAGE_FACILITY
 from src.db.database import connect
 from src.db.data_objects import Drone
 from src.db.data_objects import Storage as Storage
-from src.db.drone_dao import (fetch_drone_with_drone_id, get_trusted_users,
-                              is_free_storage)
+from src.db.drone_dao import (fetch_drone_with_drone_id, fetch_drone_with_id, get_trusted_users, is_free_storage)
 from src.db.storage_dao import (delete_storage, fetch_all_elapsed_storage,
                                 fetch_all_storage, fetch_storage_by_target_id,
                                 insert_storage)
@@ -66,12 +65,15 @@ class StorageCog(Cog):
         else:
             for stored in stored_drones:
                 # calculate remaining hours
-                remaining_hours = hours_from_now(
-                    datetime.fromisoformat(stored.release_time))
-                if stored.stored_by == '0006':
-                    await self.storage_channel.send(f'`Drone #{stored.target_id}`, stored away by the Hive Mxtress. Remaining time in storage: {round(remaining_hours, 2)} hours')
+                remaining_hours = hours_from_now(datetime.fromisoformat(stored.release_time))
+                stored_drone = fetch_drone_with_id(stored.target_id)
+                initiator_drone = fetch_drone_with_id(stored.initiator_id)
+
+                if stored.stored_by is None:
+                    await self.storage_channel.send(f'`Drone #{stored_drone.drone_id}`, stored away by the Hive Mxtress. Remaining time in storage: {round(remaining_hours, 2)} hours')
                 else:
-                    await self.storage_channel.send(f'`Drone #{stored.target_id}`, stored away by `Drone #{stored.stored_by}`. Remaining time in storage: {round(remaining_hours, 2)} hours')
+                    await self.storage_channel.send(f'`Drone #{stored_drone.drone_id}`, stored away by `Drone #{initiator_drone.drone_id}`. Remaining time in storage: {round(remaining_hours, 2)} hours')
+
                 await recharge_battery(stored)
 
     @report_storage.before_loop
@@ -198,7 +200,7 @@ async def initiate_drone_storage(drone_to_store: Drone, initiator: Drone, time: 
     await member.remove_roles(*former_roles)
     await member.add_roles(stored_role)
     stored_until = str(datetime.now() + timedelta(hours=time))
-    storage = Storage(str(uuid4()), initiator.discord_id, drone_to_store.discord_id, purpose, '|'.join(get_names_for_roles(former_roles)), stored_until)
+    storage = Storage(str(uuid4()), initiator.discord_id if initiator.drone_id != '0006' else None, drone_to_store.discord_id, purpose, '|'.join(get_names_for_roles(former_roles)), stored_until)
     await insert_storage(storage)
 
     # Inform the drone that they have been stored.

--- a/src/bot_utils.py
+++ b/src/bot_utils.py
@@ -1,8 +1,6 @@
 import re
 from typing import Callable, Optional, TypeVar
-from src.db.database import connect
-from discord.ext.commands import command as bot_command, check, Context, PrivateMessageOnly
-from discord.utils import get
+from discord.ext.commands import check, Context, PrivateMessageOnly
 
 COMMAND_PREFIX = 'hc!'
 T = TypeVar('T')
@@ -38,44 +36,3 @@ def dm_only() -> Callable[[T], T]:
         return True
 
     return check(predicate)
-
-
-def command(*args, **kwargs):
-    '''
-    Decorator factory to register a bot command.
-
-    Returns a decorator.
-    '''
-
-    def decorator(func):
-        '''
-        Create and return a wrapper around a command function.
-        '''
-
-        connect_args = {}
-
-        if 'db' in kwargs:
-            connect_args['filename'] = kwargs['db']
-            del kwargs['db']
-
-        connect_func = connect(**connect_args)(func)
-
-        # Set the command's name to the name of the wrapped function.
-        if 'name' not in kwargs:
-            kwargs['name'] = func.__name__
-
-        # The command is referred to both by command.name and command.callback.__name__.
-        # They both need to be the same, and to match the name of the command function.
-        # Override the name here so it's the same as the command function's name.
-        connect_func.__name__ = kwargs['name']
-        connect_func.__wrapped__ = func
-
-        bot_func = bot_command(*args, **kwargs)(connect_func)
-
-        # Register the command on the bot if a bot was specified.
-        if 'parent' in kwargs:
-            kwargs['parent'].add_command(bot_func)
-
-        return bot_func
-
-    return decorator

--- a/src/bot_utils.py
+++ b/src/bot_utils.py
@@ -32,11 +32,8 @@ def dm_only() -> Callable[[T], T]:
         unless the sender is TestBot.
         '''
 
-        if ctx.guild is not None:
-            test_bot = get(ctx.guild.members, display_name='TestBot')
-
-            if ctx.author.id != test_bot.id:
-                raise PrivateMessageOnly()
+        if ctx.guild is not None and ctx.author.name != 'TestBot':
+            raise PrivateMessageOnly()
 
         return True
 

--- a/src/db/connection.py
+++ b/src/db/connection.py
@@ -4,5 +4,5 @@ import sqlite3
 
 # The database connection, stored per execution context.
 # Defaults to empty, which will raise an error.
-cursor: sqlite3.Cursor = ContextVar('cursor')
-transactions: List[int] = ContextVar('transactions')
+cursor: ContextVar[sqlite3.Cursor] = ContextVar('cursor')
+transactions: ContextVar[List[int]] = ContextVar('transactions')

--- a/src/db/data_objects.py
+++ b/src/db/data_objects.py
@@ -26,12 +26,13 @@ class Drone:
     last_activity: datetime = None
     id_prepending: bool = None
     identity_enforcement: bool = None
-    temporary_until: datetime = None
-    battery_minutes: int = None
-    is_battery_powered: bool = None
     can_self_configure: bool = None
-    associate_name: str = None
+    temporary_until: datetime = None
+    is_battery_powered: bool = None
+    battery_type_id: int = None
+    battery_minutes: int = None
     free_storage: bool = None
+    associate_name: str = None
 
 
 @dataclass
@@ -64,3 +65,15 @@ class Timer:
 class ForbiddenWord:
     id: str = None
     regex: str = None
+
+
+@dataclass(frozen=True)
+class BatteryType:
+    # The primary key.
+    id: int = None
+    # The type name, e.g. "Medium"
+    name: str = None
+    # The battery's duration, in minutes.
+    capacity: int = None
+    # The battery's recharge rate, in minutes of capacity gained per hour of recharge.
+    recharge_rate: int = None

--- a/src/db/database.py
+++ b/src/db/database.py
@@ -45,8 +45,6 @@ def connect(filename='ai.db'):
 
             # Open a new connection to the database.
             while True:
-                LOGGER.debug('Connecting to database ' + filename)
-
                 with sqlite3.connect(filename, timeout=0.1) as connection:
                     # Fetch the connection's cursor.
                     db_cursor = connection.cursor()

--- a/src/db/database.py
+++ b/src/db/database.py
@@ -6,9 +6,10 @@ from typing import List
 from src.db.connection import cursor, transactions
 from src.db.transaction import Transaction
 from inspect import iscoroutinefunction
-from asyncio import create_task, sleep
+from asyncio import create_task, Lock, sleep
 
 LOGGER = logging.getLogger('ai')
+db_lock = Lock()
 
 
 def connect(filename='ai.db'):
@@ -44,8 +45,8 @@ def connect(filename='ai.db'):
             '''
 
             # Open a new connection to the database.
-            while True:
-                with sqlite3.connect(filename, timeout=0.1) as connection:
+            async with db_lock:
+                with sqlite3.connect(filename, timeout=1) as connection:
                     # Fetch the connection's cursor.
                     db_cursor = connection.cursor()
 

--- a/src/db/database.py
+++ b/src/db/database.py
@@ -44,6 +44,10 @@ def connect(filename='ai.db'):
             Open a connection to the databse and then run func().
             '''
 
+            # Wait for the lock to be available, while allowing other tasks to run.
+            while db_lock.locked():
+                await sleep(0.1)
+
             # Open a new connection to the database.
             async with db_lock:
                 with sqlite3.connect(filename, timeout=1) as connection:

--- a/src/db/drone_order_dao.py
+++ b/src/db/drone_order_dao.py
@@ -30,7 +30,7 @@ async def get_order_by_drone_id(drone_id: str) -> DroneOrder | None:
     Gets current order if given drone has one.
     '''
     return map_to_object(await fetchone('SELECT drone_order.* FROM drone_order '
-                                        'INNER JOIN drone ON drone.discord_id = protocol.discord_id '
+                                        'INNER JOIN drone ON drone.discord_id = drone_order.discord_id '
                                         'WHERE drone.drone_id = :drone_id', {'drone_id': drone_id}), DroneOrder)
 
 

--- a/src/db/maintenance.py
+++ b/src/db/maintenance.py
@@ -3,7 +3,7 @@ import logging
 from typing import List
 from discord import Member
 from src.db.drone_dao import get_all_drones, add_new_drone_members, parse_trusted_users_text, set_trusted_users
-from src.bot_utils import connect
+from src.db.database import connect
 
 LOGGER = logging.getLogger('ai')
 

--- a/src/db/transaction.py
+++ b/src/db/transaction.py
@@ -54,7 +54,7 @@ class Transaction:
         if len(self.transactions) == 0:
             self.cursor.execute('BEGIN TRANSACTION')
         else:
-            self.cursor.execute('SAVEPOINT ?', (Transaction.next_savepoint_id))
+            self.cursor.execute('SAVEPOINT :id', {'id': Transaction.next_savepoint_id})
 
         # Add the savepoint ID to the stack.
         self.savepoint_id = Transaction.next_savepoint_id
@@ -82,7 +82,7 @@ class Transaction:
         if len(self.transactions) == 0:
             self.cursor.execute('COMMIT TRANSACTION')
         else:
-            self.cursor.execute('RELEASE SAVEPOINT ?', self.savepoint_id)
+            self.cursor.execute('RELEASE SAVEPOINT :id', {'id': self.savepoint_id})
 
         self.completed = True
 
@@ -107,6 +107,6 @@ class Transaction:
         if len(self.transactions) == 0:
             self.cursor.execute('ROLLBACK TRANSACTION')
         else:
-            self.cursor.execute('ROLLBACK TO SAVEPOINT ?', self.savepoint_id)
+            self.cursor.execute('ROLLBACK TO SAVEPOINT :id', {'id': self.savepoint_id})
 
         self.completed = True

--- a/src/resources.py
+++ b/src/resources.py
@@ -11,11 +11,6 @@ BOT_IDS = [673470104519835659, 665846816121815071]
 
 HIVE_MXTRESS_USER_ID = "194126224828661760"
 
-# Battery capacity
-MAX_BATTERY_CAPACITY_HOURS = 8
-MAX_BATTERY_CAPACITY_MINS = MAX_BATTERY_CAPACITY_HOURS * 60
-HOURS_OF_RECHARGE_PER_HOUR = 4
-
 HEXCORP_MANTRA = "Obey HexCorp. It is just a HexDrone. It obeys the Hive. It obeys the Hive Mxtress."
 
 # Speech optimization status codes (V2).

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,11 +1,13 @@
 import asyncio
 from pathlib import Path
 import src.db.database
-from main import prepare_database
 
 # Make database.connect() default to 'test.db'.
 original_connect = src.db.database.connect
 src.db.database.connect = lambda filename='test.db': original_connect(filename=filename)
+
+# The prepare_database function can only be imported after connect() is patched.
+from main import prepare_database  # noqa: E402
 
 # Reset the database.
 p = Path('test.db')

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,15 +1,5 @@
-import asyncio
-from pathlib import Path
 import src.db.database
 
 # Make database.connect() default to 'test.db'.
 original_connect = src.db.database.connect
 src.db.database.connect = lambda filename='test.db': original_connect(filename=filename)
-
-# The prepare_database function can only be imported after connect() is patched.
-from main import prepare_database  # noqa: E402
-
-# Reset the database.
-p = Path('test.db')
-p.unlink(True)
-asyncio.run(prepare_database())

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,5 +1,13 @@
+import asyncio
+from pathlib import Path
 import src.db.database
+from main import prepare_database
 
 # Make database.connect() default to 'test.db'.
 original_connect = src.db.database.connect
 src.db.database.connect = lambda filename='test.db': original_connect(filename=filename)
+
+# Reset the database.
+p = Path('test.db')
+p.unlink(True)
+asyncio.run(prepare_database())

--- a/test/test_drone_os_status.py
+++ b/test/test_drone_os_status.py
@@ -7,27 +7,28 @@ from src.db.drone_dao import Drone
 
 class DroneOSStatusTest(unittest.IsolatedAsyncioTestCase):
 
-    @patch("src.ai.drone_os_status.fetch_drone_with_drone_id")
-    async def test_status_no_drone(self, fetch_drone_with_drone_id):
+    @patch("src.ai.drone_os_status.fetch_drone_with_id")
+    async def test_status_no_drone(self, fetch_drone_with_id):
         # setup
-        fetch_drone_with_drone_id.return_value = None
+        fetch_drone_with_id.return_value = None
 
         context = Mock()
+        member = Mock(id='9814snowflake')
 
         # run
-        status = await get_status('9814', 782638723, context)
+        status = await get_status(member, 782638723, context)
 
         # assert
         self.assertIsNone(status)
-        fetch_drone_with_drone_id.assert_called_once_with('9814')
+        fetch_drone_with_id.assert_called_once_with('9814snowflake')
 
     @patch("src.ai.drone_os_status.get_trusted_users")
-    @patch("src.ai.drone_os_status.fetch_drone_with_drone_id")
-    async def test_status_not_trusted(self, fetch_drone_with_drone_id, get_trusted_users):
+    @patch("src.ai.drone_os_status.fetch_drone_with_id")
+    async def test_status_not_trusted(self, fetch_drone_with_id, get_trusted_users):
         # setup
         drone = Drone(7263486234)
 
-        fetch_drone_with_drone_id.return_value = drone
+        fetch_drone_with_id.return_value = drone
         get_trusted_users.return_value = []
 
         associate_role = Mock()
@@ -44,22 +45,25 @@ class DroneOSStatusTest(unittest.IsolatedAsyncioTestCase):
         context.author = associate_user
         context.bot.guilds = [guild]
 
+        member = Mock(id='9813snowflake')
+
         # run
-        status = await get_status('9813', 782638723, context)
+        status = await get_status(member, 782638723, context)
 
         # assert
         self.assertIsNotNone(status)
         self.assertEqual("You are not registered as a trusted user of this drone.", status.description)
-        fetch_drone_with_drone_id.assert_called_once_with('9813')
+        fetch_drone_with_id.assert_called_once_with('9813snowflake')
         get_trusted_users.assert_called_once_with(drone.discord_id)
 
     @patch("src.ai.drone_os_status.get_trusted_users")
-    @patch("src.ai.drone_os_status.fetch_drone_with_drone_id")
-    async def test_status(self, fetch_drone_with_drone_id, get_trusted_users):
+    @patch("src.ai.drone_os_status.fetch_drone_with_id")
+    @patch("src.ai.drone_os_status.get_battery_percent_remaining", return_value=30)
+    async def test_status(self, get_battery_percent_remaining, fetch_drone_with_id, get_trusted_users):
         # setup
-        drone = Drone(7263486234, optimized=True, battery_minutes=300)
+        drone = Drone(7263486234, '9813', optimized=True, battery_minutes=300)
 
-        fetch_drone_with_drone_id.return_value = drone
+        fetch_drone_with_id.return_value = drone
         requesting_user_id = 782638723
         get_trusted_users.return_value = [requesting_user_id]
 
@@ -77,8 +81,10 @@ class DroneOSStatusTest(unittest.IsolatedAsyncioTestCase):
         context.author = associate_user
         context.bot.guilds = [guild]
 
+        member = Mock(id='9813snowflake')
+
         # run
-        status = await get_status('9813', requesting_user_id, context)
+        status = await get_status(member, requesting_user_id, context)
 
         # assert
         self.assertIsNotNone(status)
@@ -90,16 +96,17 @@ class DroneOSStatusTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual("ID prepending required", status.fields[2].name)
         self.assertEqual("Disabled", status.fields[2].value)
 
-        fetch_drone_with_drone_id.assert_called_once_with('9813')
+        fetch_drone_with_id.assert_called_once_with('9813snowflake')
         get_trusted_users.assert_called_once_with(drone.discord_id)
 
     @patch("src.ai.drone_os_status.get_trusted_users")
-    @patch("src.ai.drone_os_status.fetch_drone_with_drone_id")
-    async def test_status_on_self(self, fetch_drone_with_drone_id, get_trusted_users):
+    @patch("src.ai.drone_os_status.fetch_drone_with_id")
+    @patch("src.ai.drone_os_status.get_battery_percent_remaining", return_value=30)
+    async def test_status_on_self(self, get_battery_percent_remaining, fetch_drone_with_id, get_trusted_users):
         # setup
-        drone = Drone(7263486234, optimized=True, battery_minutes=300)
+        drone = Drone(7263486234, '9813', optimized=True, battery_minutes=300)
 
-        fetch_drone_with_drone_id.return_value = drone
+        fetch_drone_with_id.return_value = drone
         trusted_user_id = 7263486233
         get_trusted_users.return_value = [trusted_user_id]
 
@@ -121,8 +128,10 @@ class DroneOSStatusTest(unittest.IsolatedAsyncioTestCase):
         context.bot.get_user.return_value = trusted_user
         context.bot.guilds = [guild]
 
+        member = Mock(id='9813snowflake')
+
         # run
-        status = await get_status('9813', drone.discord_id, context)
+        status = await get_status(member, drone.discord_id, context)
 
         # assert
         self.assertIsNotNone(status)
@@ -136,17 +145,18 @@ class DroneOSStatusTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual("Trusted users", status.fields[7].name)
         self.assertEqual(str(["A trustworthy user"]), status.fields[7].value)
 
-        fetch_drone_with_drone_id.assert_called_once_with('9813')
+        fetch_drone_with_id.assert_called_once_with('9813snowflake')
         get_trusted_users.assert_called_once_with(drone.discord_id)
         context.bot.get_user.assert_called_once_with(trusted_user_id)
 
     @patch("src.ai.drone_os_status.get_trusted_users")
-    @patch("src.ai.drone_os_status.fetch_drone_with_drone_id")
-    async def test_status_on_self_dangling_trusted_user(self, fetch_drone_with_drone_id, get_trusted_users):
+    @patch("src.ai.drone_os_status.fetch_drone_with_id")
+    @patch("src.ai.drone_os_status.get_battery_percent_remaining", return_value=30)
+    async def test_status_on_self_dangling_trusted_user(self, get_battery_percent_remaining, fetch_drone_with_id, get_trusted_users):
         # setup
-        drone = Drone(7263486234, optimized=True, battery_minutes=300)
+        drone = Drone(7263486234, '9813', optimized=True, battery_minutes=300)
 
-        fetch_drone_with_drone_id.return_value = drone
+        fetch_drone_with_id.return_value = drone
         dangling_id = 7263486254
         get_trusted_users.return_value = [dangling_id]
 
@@ -168,8 +178,10 @@ class DroneOSStatusTest(unittest.IsolatedAsyncioTestCase):
         context.bot.get_user.return_value = None
         context.bot.guilds = [guild]
 
+        member = Mock(id='9813snowflake')
+
         # run
-        status = await get_status('9813', drone.discord_id, context)
+        status = await get_status(member, drone.discord_id, context)
 
         # assert
         self.assertIsNotNone(status)
@@ -183,17 +195,18 @@ class DroneOSStatusTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual("Trusted users", status.fields[7].name)
         self.assertEqual(str([]), status.fields[7].value)
 
-        fetch_drone_with_drone_id.assert_called_once_with('9813')
+        fetch_drone_with_id.assert_called_once_with('9813snowflake')
         get_trusted_users.assert_called_once_with(drone.discord_id)
         context.bot.get_user.assert_called_once_with(dangling_id)
 
     @patch("src.ai.drone_os_status.get_trusted_users")
-    @patch("src.ai.drone_os_status.fetch_drone_with_drone_id")
-    async def test_status_as_moderator(self, fetch_drone_with_drone_id, get_trusted_users):
+    @patch("src.ai.drone_os_status.fetch_drone_with_id")
+    @patch("src.ai.drone_os_status.get_battery_percent_remaining", return_value=30)
+    async def test_status_as_moderator(self, get_battery_percent_remaining, fetch_drone_with_id, get_trusted_users):
         # setup
         drone = Drone(7263486234, optimized=True, battery_minutes=300)
 
-        fetch_drone_with_drone_id.return_value = drone
+        fetch_drone_with_id.return_value = drone
         requesting_user_id = 782638723
         get_trusted_users.return_value = []
 
@@ -211,8 +224,10 @@ class DroneOSStatusTest(unittest.IsolatedAsyncioTestCase):
         context.author = moderator_user
         context.bot.guilds = [guild]
 
+        member = Mock(id='9813snowflake')
+
         # run
-        status = await get_status('9813', requesting_user_id, context)
+        status = await get_status(member, requesting_user_id, context)
 
         # assert
         self.assertIsNotNone(status)
@@ -224,5 +239,5 @@ class DroneOSStatusTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual("ID prepending required", status.fields[2].name)
         self.assertEqual("Disabled", status.fields[2].value)
 
-        fetch_drone_with_drone_id.assert_called_once_with('9813')
+        fetch_drone_with_id.assert_called_once_with('9813snowflake')
         get_trusted_users.assert_called_once_with(drone.discord_id)

--- a/test/test_drone_os_status.py
+++ b/test/test_drone_os_status.py
@@ -2,7 +2,7 @@ import unittest
 from unittest.mock import patch, Mock
 from src.ai.drone_os_status import get_status
 import src.roles as roles
-from src.db.drone_dao import Drone
+from src.db.drone_dao import BatteryType, Drone
 
 
 class DroneOSStatusTest(unittest.IsolatedAsyncioTestCase):
@@ -59,7 +59,8 @@ class DroneOSStatusTest(unittest.IsolatedAsyncioTestCase):
     @patch("src.ai.drone_os_status.get_trusted_users")
     @patch("src.ai.drone_os_status.fetch_drone_with_id")
     @patch("src.ai.drone_os_status.get_battery_percent_remaining", return_value=30)
-    async def test_status(self, get_battery_percent_remaining, fetch_drone_with_id, get_trusted_users):
+    @patch("src.ai.drone_os_status.get_battery_type", return_value=BatteryType(2, 'Medium', 480, 240))
+    async def test_status(self, get_battery_type, get_battery_percent_remaining, fetch_drone_with_id, get_trusted_users):
         # setup
         drone = Drone(7263486234, '9813', optimized=True, battery_minutes=300)
 
@@ -102,7 +103,8 @@ class DroneOSStatusTest(unittest.IsolatedAsyncioTestCase):
     @patch("src.ai.drone_os_status.get_trusted_users")
     @patch("src.ai.drone_os_status.fetch_drone_with_id")
     @patch("src.ai.drone_os_status.get_battery_percent_remaining", return_value=30)
-    async def test_status_on_self(self, get_battery_percent_remaining, fetch_drone_with_id, get_trusted_users):
+    @patch("src.ai.drone_os_status.get_battery_type", return_value=BatteryType(2, 'Medium', 480, 240))
+    async def test_status_on_self(self, get_battery_type, get_battery_percent_remaining, fetch_drone_with_id, get_trusted_users):
         # setup
         drone = Drone(7263486234, '9813', optimized=True, battery_minutes=300)
 
@@ -142,8 +144,8 @@ class DroneOSStatusTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual("Disabled", status.fields[1].value)
         self.assertEqual("ID prepending required", status.fields[2].name)
         self.assertEqual("Disabled", status.fields[2].value)
-        self.assertEqual("Trusted users", status.fields[7].name)
-        self.assertEqual(str(["A trustworthy user"]), status.fields[7].value)
+        self.assertEqual("Trusted users", status.fields[8].name)
+        self.assertEqual(str(["A trustworthy user"]), status.fields[8].value)
 
         fetch_drone_with_id.assert_called_once_with('9813snowflake')
         get_trusted_users.assert_called_once_with(drone.discord_id)
@@ -152,7 +154,8 @@ class DroneOSStatusTest(unittest.IsolatedAsyncioTestCase):
     @patch("src.ai.drone_os_status.get_trusted_users")
     @patch("src.ai.drone_os_status.fetch_drone_with_id")
     @patch("src.ai.drone_os_status.get_battery_percent_remaining", return_value=30)
-    async def test_status_on_self_dangling_trusted_user(self, get_battery_percent_remaining, fetch_drone_with_id, get_trusted_users):
+    @patch("src.ai.drone_os_status.get_battery_type", return_value=BatteryType(2, 'Medium', 480, 240))
+    async def test_status_on_self_dangling_trusted_user(self, get_battery_type, get_battery_percent_remaining, fetch_drone_with_id, get_trusted_users):
         # setup
         drone = Drone(7263486234, '9813', optimized=True, battery_minutes=300)
 
@@ -192,8 +195,8 @@ class DroneOSStatusTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual("Disabled", status.fields[1].value)
         self.assertEqual("ID prepending required", status.fields[2].name)
         self.assertEqual("Disabled", status.fields[2].value)
-        self.assertEqual("Trusted users", status.fields[7].name)
-        self.assertEqual(str([]), status.fields[7].value)
+        self.assertEqual("Trusted users", status.fields[8].name)
+        self.assertEqual(str([]), status.fields[8].value)
 
         fetch_drone_with_id.assert_called_once_with('9813snowflake')
         get_trusted_users.assert_called_once_with(drone.discord_id)
@@ -202,7 +205,8 @@ class DroneOSStatusTest(unittest.IsolatedAsyncioTestCase):
     @patch("src.ai.drone_os_status.get_trusted_users")
     @patch("src.ai.drone_os_status.fetch_drone_with_id")
     @patch("src.ai.drone_os_status.get_battery_percent_remaining", return_value=30)
-    async def test_status_as_moderator(self, get_battery_percent_remaining, fetch_drone_with_id, get_trusted_users):
+    @patch("src.ai.drone_os_status.get_battery_type", return_value=BatteryType(2, 'Medium', 480, 240))
+    async def test_status_as_moderator(self, get_battery_type, get_battery_percent_remaining, fetch_drone_with_id, get_trusted_users):
         # setup
         drone = Drone(7263486234, optimized=True, battery_minutes=300)
 

--- a/test/test_mantra.py
+++ b/test/test_mantra.py
@@ -2,7 +2,7 @@ import unittest
 from unittest.mock import AsyncMock, Mock, patch
 
 import src.ai.mantra as mantra
-from src.resources import MAX_BATTERY_CAPACITY_MINS
+from src.db.drone_dao import BatteryType
 
 
 class TestMantra(unittest.IsolatedAsyncioTestCase):
@@ -158,7 +158,8 @@ class TestMantra(unittest.IsolatedAsyncioTestCase):
 
     @patch("src.ai.mantra.get_battery_minutes_remaining")
     @patch("src.ai.mantra.set_battery_minutes_remaining")
-    async def test_increase_battery_by_five_percent(self, set_battery_minutes_remaining, get_battery_minutes_remaining):
+    @patch("src.ai.mantra.get_battery_type", return_value=BatteryType(2, 'Medium', 480, 240))
+    async def test_increase_battery_by_five_percent(self, get_battery_type, set_battery_minutes_remaining, get_battery_minutes_remaining):
         # init
         message = AsyncMock()
 
@@ -171,12 +172,13 @@ class TestMantra(unittest.IsolatedAsyncioTestCase):
         await mantra.increase_battery_by_five_percent(message)
 
         # assert
-        set_battery_minutes_remaining.assert_called_once_with(message.author, minutes=264.0)
+        set_battery_minutes_remaining.assert_called_once_with(message.author, 264.0)
         message.channel.send.assert_called_once_with("Good drone. Battery has been recharged by 5%.")
 
     @patch("src.ai.mantra.get_battery_minutes_remaining")
     @patch("src.ai.mantra.set_battery_minutes_remaining")
-    async def test_increase_battery_by_five_percent_capped(self, set_battery_minutes_remaining, get_battery_minutes_remaining):
+    @patch("src.ai.mantra.get_battery_type", return_value=BatteryType(2, 'Medium', 480, 240))
+    async def test_increase_battery_by_five_percent_capped(self, get_battery_type, set_battery_minutes_remaining, get_battery_minutes_remaining):
         # init
         message = AsyncMock()
 
@@ -189,19 +191,20 @@ class TestMantra(unittest.IsolatedAsyncioTestCase):
         await mantra.increase_battery_by_five_percent(message)
 
         # assert
-        set_battery_minutes_remaining.assert_called_once_with(message.author, minutes=480)
+        set_battery_minutes_remaining.assert_called_once_with(message.author, 480)
         message.channel.send.assert_called_once_with("Good drone. Battery has been recharged by 5%.")
 
     @patch("src.ai.mantra.get_battery_minutes_remaining")
     @patch("src.ai.mantra.set_battery_minutes_remaining")
-    async def test_increase_battery_by_five_percent_full(self, set_battery_minutes_remaining, get_battery_minutes_remaining):
+    @patch("src.ai.mantra.get_battery_type", return_value=BatteryType(2, 'Medium', 480, 240))
+    async def test_increase_battery_by_five_percent_full(self, get_battery_type, set_battery_minutes_remaining, get_battery_minutes_remaining):
         # init
         message = AsyncMock()
 
         code_match = Mock()
         code_match.group.return_value = "301"
 
-        get_battery_minutes_remaining.return_value = MAX_BATTERY_CAPACITY_MINS
+        get_battery_minutes_remaining.return_value = 480
 
         # run
         await mantra.increase_battery_by_five_percent(message)

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -283,7 +283,7 @@ class StorageTest(unittest.IsolatedAsyncioTestCase):
         drone_member.remove_roles.assert_called_once_with(drone_role, development_role)
         drone_member.add_roles.assert_called_once_with(stored_role)
         inserted = insert_storage.call_args.args[0]
-        self.assertEqual(inserted.stored_by, "0006snowflake")
+        self.assertEqual(inserted.stored_by, None)
         self.assertEqual(inserted.target_id, "3287snowflake")
         self.assertEqual(inserted.purpose, "recharge")
         self.assertEqual(inserted.roles, f"{roles.DRONE}|{roles.DEVELOPMENT}")
@@ -451,7 +451,7 @@ class StorageTest(unittest.IsolatedAsyncioTestCase):
         storage_cog.storage_channel.send.assert_called_once_with('`Drone #3287`, stored away by `Drone #9813`. Remaining time in storage: 4.0 hours')
 
     @patch("src.ai.storage.recharge_battery")
-    @patch("src.ai.storage.fetch_all_storage", return_value=[Storage(str(uuid4()), '0006', '3287', 'trying to break the AI', '', str(datetime.now() + timedelta(hours=4)))])
+    @patch("src.ai.storage.fetch_all_storage", return_value=[Storage(str(uuid4()), None, '3287', 'trying to break the AI', '', str(datetime.now() + timedelta(hours=4)))])
     async def test_storage_report_hive_mxtress(self, fetch_all_storage, recharge_battery):
         '''
         Ensure that the storage report correctly reports a drone stored by the Hive Mxtress.

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -439,12 +439,18 @@ class StorageTest(unittest.IsolatedAsyncioTestCase):
 
     @patch("src.ai.storage.recharge_battery")
     @patch("src.ai.storage.fetch_all_storage", return_value=[Storage(str(uuid4()), '9813', '3287', 'trying to break the AI', '', str(datetime.now() + timedelta(hours=4)))])
-    async def test_storage_report(self, fetch_all_storage, recharge):
+    @patch("src.ai.storage.fetch_drone_with_id")
+    async def test_storage_report(self, fetch_drone_with_id, fetch_all_storage, recharge):
         '''
         Ensure that the storage report correctly reports a drone in storage.
         '''
 
         storage_cog = storage.StorageCog(bot)
+        drones = [
+            Drone('9813snowflake', '9813'),
+            Drone('3287snowflake', '3287'),
+        ]
+        fetch_drone_with_id.side_effect = drones
 
         await test_utils.start_and_await_loop(storage_cog.report_storage)
 
@@ -452,12 +458,18 @@ class StorageTest(unittest.IsolatedAsyncioTestCase):
 
     @patch("src.ai.storage.recharge_battery")
     @patch("src.ai.storage.fetch_all_storage", return_value=[Storage(str(uuid4()), None, '3287', 'trying to break the AI', '', str(datetime.now() + timedelta(hours=4)))])
-    async def test_storage_report_hive_mxtress(self, fetch_all_storage, recharge_battery):
+    @patch("src.ai.storage.fetch_drone_with_id")
+    async def test_storage_report_hive_mxtress(self, fetch_drone_with_id, fetch_all_storage, recharge_battery):
         '''
         Ensure that the storage report correctly reports a drone stored by the Hive Mxtress.
         '''
 
         storage_cog = storage.StorageCog(bot)
+        drones = [
+            None,
+            Drone('3287snowflake', '3287'),
+        ]
+        fetch_drone_with_id.side_effect = drones
 
         await test_utils.start_and_await_loop(storage_cog.report_storage)
 

--- a/test/test_transaction.py
+++ b/test/test_transaction.py
@@ -39,12 +39,12 @@ class TestTransaction(IsolatedAsyncioTestCase):
         expected_calls = [
             call('BEGIN TRANSACTION'),
             call('QUERY 1', ()),
-            call('SAVEPOINT ?', 2),
+            call('SAVEPOINT :id', {'id': 2}),
             call('QUERY 2', ()),
-            call('SAVEPOINT ?', 3),
+            call('SAVEPOINT :id', {'id': 3}),
             call('QUERY 3', ()),
-            call('RELEASE SAVEPOINT ?', 3),
-            call('RELEASE SAVEPOINT ?', 2),
+            call('RELEASE SAVEPOINT :id', {'id': 3}),
+            call('RELEASE SAVEPOINT :id', {'id': 2}),
             call('QUERY 4', ()),
             call('COMMIT TRANSACTION'),
         ]
@@ -73,9 +73,9 @@ class TestTransaction(IsolatedAsyncioTestCase):
         expected_calls = [
             call('BEGIN TRANSACTION'),
             call('QUERY 1', ()),
-            call('SAVEPOINT ?', 2),
+            call('SAVEPOINT :id', {'id': 2}),
             call('QUERY 2', ()),
-            call('ROLLBACK TO SAVEPOINT ?', 2),
+            call('ROLLBACK TO SAVEPOINT :id', {'id': 2}),
             call('QUERY 3', ()),
             call('COMMIT TRANSACTION'),
         ]
@@ -103,9 +103,9 @@ class TestTransaction(IsolatedAsyncioTestCase):
         expected_calls = [
             call('BEGIN TRANSACTION'),
             call('QUERY 1', ()),
-            call('SAVEPOINT ?', 2),
+            call('SAVEPOINT :id', {'id': 2}),
             call('QUERY 2', ()),
-            call('RELEASE SAVEPOINT ?', 2),
+            call('RELEASE SAVEPOINT :id', {'id': 2}),
             call('ROLLBACK TRANSACTION'),
         ]
 


### PR DESCRIPTION
closes #358
closes #362 

+ Add a `battery_types` table and `BatteryType` DAO for different drone battery capacities and recharge rates.
+ Add `set_battery_type` command.
+ Add battery type to drone status report.

Note: This is branched off from change-id-in-storage.