### PR TITLE
Big text length

### DIFF
--- a/main.py
+++ b/main.py
@@ -339,12 +339,14 @@ async def on_command_error(context, error):
     if isinstance(error, MissingRequiredArgument):
         # missing arguments should not be that noisy and can be reported to the user
         LOGGER.info(f"Missing parameter {error.param.name} reported to user.")
-        await context.send(f"`{error.param.name}` is a required argument that is missing.")
+        await context.reply(f"`{error.param.name}` is a required argument that is missing.")
     elif isinstance(error, PrivateMessageOnly):
-        await context.send("This message can only be used in DMs with the AI. Please consult the help for more information.")
+        await context.reply("This message can only be used in DMs with the AI. Please consult the help for more information.")
     elif isinstance(error.original, ValidationError):
-        await context.send(str(error.original))
+        LOGGER.info('Validation error: ' + str(error.original))
+        await context.reply(str(error.original))
     else:
+        await context.reply(glitch_message.glitch_text('Command processing failure'))
         LOGGER.error(f"!!! Exception caught in {context.command} command !!!")
         LOGGER.info("".join(TracebackException(type(error), error, error.__traceback__, limit=None).format(chain=True)))
 

--- a/src/ai/emote.py
+++ b/src/ai/emote.py
@@ -7,6 +7,7 @@ from discord.utils import get
 
 from src.channels import DRONE_HIVE_CHANNELS
 from src.bot_utils import COMMAND_PREFIX
+from src.validation_error import ValidationError
 
 LOGGER = logging.getLogger('ai')
 
@@ -24,22 +25,23 @@ class EmoteCog(Cog):
         '''
         Let the AI say things using emotes.
         '''
+
         if context.channel.name not in DRONE_HIVE_CHANNELS:
-            reply = generate_big_text(context.channel, sentence)
-            if reply:
-                await context.send(reply)
+            await context.send(generate_big_text(context.channel, sentence))
 
 
 def clean_sentence(sentence):
-    # Removes custom emojis (<:name:id>) and returns the lowercase version
+    '''
+    Remove custom emojis (<:name:id>) and returns the lowercase version.
+    '''
+
     return re.sub(r'<:(.*?):\d{18}>', '', sentence).lower()
 
 
 def generate_big_text(channel: discord.TextChannel, sentence):
-
-    LOGGER.debug("In generate_big_text function.")
-
-    LOGGER.debug("Sanatizing sentence of custom emojis.")
+    '''
+    Replace text with matching emojis.
+    '''
 
     sentence = clean_sentence(sentence)
 
@@ -64,14 +66,11 @@ def generate_big_text(channel: discord.TextChannel, sentence):
             reply += str(emoji)
 
     message_length = len(reply)
-    LOGGER.debug(f"About to send big-text message of length {message_length}")
 
-    if message_length > 0 and message_length <= 2000:
-        LOGGER.info(f"Sending big-text message of length {message_length} and content '{sentence}'")
-        return f"> {reply}"
-    elif message_length > 2000:
-        LOGGER.info("big-text message was too long to send.")
-        return None
-    else:
-        LOGGER.debug("big-text request message contained no acceptable content.")
-        return None
+    if message_length > 2000:
+        raise ValidationError('Message is too long.')
+
+    if message_length == 0:
+        raise ValidationError('Message contained no acceptable content.')
+
+    return f"> {reply}"

--- a/src/validation_error.py
+++ b/src/validation_error.py
@@ -1,5 +1,7 @@
-class ValidationError(Exception):
+from discord.ext.commands import CheckFailure
+
+
+class ValidationError(CheckFailure):
     '''
     An error that should be reported to the user.
     '''
-    pass

--- a/test/test_emote.py
+++ b/test/test_emote.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import patch, AsyncMock
 import discord
 from src.ai.emote import generate_big_text
+from src.validation_error import ValidationError
 
 
 class TestEmote(unittest.TestCase):
@@ -27,14 +28,22 @@ class TestEmote(unittest.TestCase):
 
     @patch("src.ai.emote.get", return_value=normal_mock_emoji)
     def test_return_none_if_generated_text_too_long(self, mocked_get):
-        self.assertIsNone(generate_big_text(TestEmote.mock_channel, "9813 is such a good development drone that i could write about how wonderful they are and the bigtext generator would return none because there are too many good things to say about it"))
-        self.assertIsNone(generate_big_text(TestEmote.mock_channel, "and since we need to do two tests i'd like to mention that 3287 is also a sweet little thing and 5890 always loves to have it around even when it bullies it by calling it a good drone and making it blush"))
+        with self.assertRaises(ValidationError):
+            generate_big_text(TestEmote.mock_channel, "9813 is such a good development drone that i could write about how wonderful they are and the bigtext generator would return none because there are too many good things to say about it")
+
+        with self.assertRaises(ValidationError):
+            generate_big_text(TestEmote.mock_channel, "and since we need to do two tests i'd like to mention that 3287 is also a sweet little thing and 5890 always loves to have it around even when it bullies it by calling it a good drone and making it blush")
 
     @patch("src.ai.emote.get", return_value=normal_mock_emoji)
     def test_return_none_if_input_contains_no_convertible_material(self, mocked_get):
-        self.assertIsNone(generate_big_text(TestEmote.mock_channel, "ʰᵉʷʷᵒˀˀ"))
-        self.assertIsNone(generate_big_text(TestEmote.mock_channel, "ᵐʷˢᶦᵗᵉʳ_ᵒᵇᵃᵐᵃˀ"))
-        self.assertIsNone(generate_big_text(TestEmote.mock_channel, "_____"))
+        with self.assertRaises(ValidationError):
+            generate_big_text(TestEmote.mock_channel, "ʰᵉʷʷᵒˀˀ")
+
+        with self.assertRaises(ValidationError):
+            generate_big_text(TestEmote.mock_channel, "ᵐʷˢᶦᵗᵉʳ_ᵒᵇᵃᵐᵃˀ")
+
+        with self.assertRaises(ValidationError):
+            generate_big_text(TestEmote.mock_channel, "_____")
 
     @patch("src.ai.emote.get", return_value=normal_mock_emoji)
     def test_generator_removes_custom_emojis_from_input(self, mocked_get):

--- a/test/utils.py
+++ b/test/utils.py
@@ -84,6 +84,9 @@ def cog(CogType: Type[Cog]) -> Callable[[Any, Any], Any]:
             message.guild = guild
             message.content = content
 
+            message.state = AsyncMock()
+            message.state.create_message = MagicMock()
+
             for n, v in kwargs.items():
                 setattr(message, n, v)
 


### PR DESCRIPTION
closes #280 

Make `ValidationError` inherit from `CheckFailure` to help differentiate it from an unexpected exception.