### PR TITLE
bumped to pycord 2.5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-py-cord ~= 2.4.1
+py-cord ~= 2.5.0
 glitch-this ~= 1.0.2


### PR DESCRIPTION
Increases the version of pycord we use to 2.5.0. No incompatibility noticed.

closes #436 