### PR TITLE
changed battery functions to use discord_id instead of the whole member

### DIFF
--- a/src/ai/battery.py
+++ b/src/ai/battery.py
@@ -263,14 +263,14 @@ def determine_battery_emoji(battery_percentage: int, guild: Guild) -> Emoji | st
         return "[BATTERY ERROR]"
 
 
-async def recharge_battery(member: Member) -> None:
+async def recharge_battery(discord_id: int) -> None:
     '''
     Fills the battery of a drone in storage up to max.
     '''
 
-    current_minutes_remaining = await get_battery_minutes_remaining(member)
-    battery_type = await get_battery_type(member)
-    await set_battery_minutes_remaining(member, min(battery_type.capacity, current_minutes_remaining + battery_type.recharge_rate))
+    current_minutes_remaining = await get_battery_minutes_remaining(discord_id)
+    battery_type = await get_battery_type(discord_id)
+    await set_battery_minutes_remaining(discord_id, min(battery_type.capacity, current_minutes_remaining + battery_type.recharge_rate))
 
 
 async def drain_battery(member: Member):
@@ -278,7 +278,7 @@ async def drain_battery(member: Member):
     Reduces the battery charge of a drone by 10%.
     '''
 
-    minutes_remaining = await get_battery_minutes_remaining(member)
-    battery_type = await get_battery_type(member)
+    minutes_remaining = await get_battery_minutes_remaining(member.id)
+    battery_type = await get_battery_type(member.id)
 
-    await set_battery_minutes_remaining(member, minutes_remaining - battery_type.capacity / 10)
+    await set_battery_minutes_remaining(member.id, minutes_remaining - battery_type.capacity / 10)

--- a/src/ai/drone_configuration.py
+++ b/src/ai/drone_configuration.py
@@ -140,12 +140,12 @@ class DroneConfigurationCog(Cog):
 
     @guild_only()
     @command(aliases=['battery', 'tbp'], brief=[BRIEF_DRONE_OS], usage=f'{COMMAND_PREFIX}toggle_battery_power 0001')
-    async def toggle_battery_power(self, context, drones: Greedy[Union[discord.Member, DroneMemberConverter]], minutes: NamedParameterConverter(MINUTES_PARAMETER, int) = 0):
+    async def toggle_battery_power(self, context, members: Greedy[Union[discord.Member, DroneMemberConverter]], minutes: NamedParameterConverter(MINUTES_PARAMETER, int) = 0):
         '''
         Lets the Hive Mxtress or trusted users toggle whether or not a drone is battery powered.
         '''
         await toggle_parameter(context,
-                               drones,
+                               members,
                                "is_battery_powered",
                                get(context.guild.roles, name=BATTERY_POWERED),
                                is_battery_powered,
@@ -155,10 +155,10 @@ class DroneConfigurationCog(Cog):
                                minutes)
         # Additionally, reset the battery of any drone regardless of whether or not it's being toggled on or off.
         # And remove drained role if added.
-        for drone in drones:
-            battery_type = await get_battery_type(drone.discord_id)
-            await set_battery_minutes_remaining(drone.discord_id, battery_type.capacity)
-            await drone.remove_roles(get(context.guild.roles, name=BATTERY_DRAINED))
+        for member in members:
+            battery_type = await get_battery_type(member.id)
+            await set_battery_minutes_remaining(member.id, battery_type.capacity)
+            await member.remove_roles(get(context.guild.roles, name=BATTERY_DRAINED))
 
 
 async def rename_drone(context, old_id: str, new_id: str):

--- a/src/ai/drone_configuration.py
+++ b/src/ai/drone_configuration.py
@@ -156,8 +156,8 @@ class DroneConfigurationCog(Cog):
         # Additionally, reset the battery of any drone regardless of whether or not it's being toggled on or off.
         # And remove drained role if added.
         for drone in drones:
-            battery_type = await get_battery_type(drone)
-            await set_battery_minutes_remaining(drone, battery_type.capacity)
+            battery_type = await get_battery_type(drone.discord_id)
+            await set_battery_minutes_remaining(drone.discord_id, battery_type.capacity)
             await drone.remove_roles(get(context.guild.roles, name=BATTERY_DRAINED))
 
 

--- a/src/ai/drone_os_status.py
+++ b/src/ai/drone_os_status.py
@@ -49,7 +49,7 @@ async def get_status(member: discord.Member, requesting_user: int, context) -> d
         embed.description = "You are not registered as a trusted user of this drone."
         return embed
 
-    battery_type = await get_battery_type(member)
+    battery_type = await get_battery_type(member.id)
 
     # assemble description
     if is_trusted_user:

--- a/src/ai/mantra.py
+++ b/src/ai/mantra.py
@@ -51,12 +51,12 @@ async def increase_battery_by_five_percent(message: discord.Message):
     Increases the battery of the given drone by 5 percent capping at 100% capacity.
     Acknowledges the mantra repetitions by sending a message in the mantra channel as well.
     '''
-    minutes_remaining = await get_battery_minutes_remaining(message.author)
-    battery_type = await get_battery_type(message.author)
+    minutes_remaining = await get_battery_minutes_remaining(message.author.id)
+    battery_type = await get_battery_type(message.author.id)
 
     if minutes_remaining >= battery_type.capacity:
         await message.channel.send("Good drone. Battery already at 100%.")
         return
 
-    await set_battery_minutes_remaining(message.author, min(minutes_remaining + battery_type.capacity / 20, battery_type.capacity))
+    await set_battery_minutes_remaining(message.author.id, min(minutes_remaining + battery_type.capacity / 20, battery_type.capacity))
     await message.channel.send("Good drone. Battery has been recharged by 5%.")

--- a/src/ai/storage.py
+++ b/src/ai/storage.py
@@ -74,7 +74,7 @@ class StorageCog(Cog):
                 else:
                     await self.storage_channel.send(f'`Drone #{stored_drone.drone_id}`, stored away by `Drone #{initiator_drone.drone_id}`. Remaining time in storage: {round(remaining_hours, 2)} hours')
 
-                await recharge_battery(stored)
+                await recharge_battery(stored.target_id)
 
     @report_storage.before_loop
     async def get_storage_channel(self):

--- a/src/db/drone_dao.py
+++ b/src/db/drone_dao.py
@@ -167,24 +167,24 @@ async def deincrement_battery_minutes_remaining(member: Optional[discord.Member]
         raise ValueError('Could not deincrement drone battery. No Discord member or drone ID provided.')
 
 
-async def set_battery_minutes_remaining(member: discord.Member, minutes: int):
+async def set_battery_minutes_remaining(discord_id: int, minutes: int):
     '''
     Sets the value of battery_minutes to the specified amount.
     '''
 
-    await change('UPDATE drone SET battery_minutes = :minutes WHERE discord_id = :discord', {'minutes': max(0, minutes), 'discord': member.id})
+    await change('UPDATE drone SET battery_minutes = :minutes WHERE discord_id = :discord', {'minutes': max(0, minutes), 'discord': discord_id})
 
 
-async def get_battery_minutes_remaining(member: discord.Member) -> int:
+async def get_battery_minutes_remaining(discord_id: int) -> int:
     '''
     Gets value of battery_minutes from drone table based on a given drone's Discord ID.
     Raises an Exception if the drone is not found.
     '''
 
-    drone = await fetchone('SELECT battery_minutes FROM drone WHERE discord_id = :discord', {'discord': member.id})
+    drone = await fetchone('SELECT battery_minutes FROM drone WHERE discord_id = :discord', {'discord': discord_id})
 
     if drone is None:
-        raise Exception('No drone record for member ' + str(member.id))
+        raise Exception('No drone record for member with id ' + str(discord_id))
 
     return drone['battery_minutes']
 
@@ -259,7 +259,7 @@ async def is_free_storage(drone: Drone) -> bool:
     return free_storage_drone is not None and bool(free_storage_drone['free_storage'])
 
 
-async def get_battery_type(member: discord.Member) -> BatteryType:
+async def get_battery_type(discord_id: int) -> BatteryType:
     '''
     Fetch the battery type information for the given member.
 
@@ -273,10 +273,10 @@ async def get_battery_type(member: discord.Member) -> BatteryType:
         'WHERE drone.discord_id = :discord_id'
     )
 
-    result = map_to_object(await fetchone(query, {'discord_id': member.id}), BatteryType)
+    result = map_to_object(await fetchone(query, {'discord_id': discord_id}), BatteryType)
 
     if result is None:
-        raise Exception('Failed to get battery type for member ' + str(member.id))
+        raise Exception('Failed to get battery type for member with ID ' + str(discord_id))
 
     return result
 

--- a/test/test_battery.py
+++ b/test/test_battery.py
@@ -21,9 +21,9 @@ class TestBattery(unittest.IsolatedAsyncioTestCase):
         member = Mock()
         member.id = '5890snowflake'
 
-        await battery.recharge_battery(member)
+        await battery.recharge_battery(member.id)
 
-        set_bat_mins.assert_called_once_with(member, 20 + 240)
+        set_bat_mins.assert_called_once_with(member.id, 20 + 240)
 
     @patch("src.ai.battery.get_battery_minutes_remaining", return_value=320)
     @patch("src.ai.battery.set_battery_minutes_remaining")
@@ -40,8 +40,8 @@ class TestBattery(unittest.IsolatedAsyncioTestCase):
 
         await battery.drain_battery(member)
 
-        get_bat_mins.assert_called_once_with(member)
-        set_bat_mins.assert_called_once_with(member, 320 - 480 / 10)
+        get_bat_mins.assert_called_once_with(member.id)
+        set_bat_mins.assert_called_once_with(member.id, 320 - 480 / 10)
 
     @patch("src.ai.battery.get_battery_minutes_remaining", return_value=500)
     @patch("src.ai.battery.set_battery_minutes_remaining")
@@ -55,9 +55,9 @@ class TestBattery(unittest.IsolatedAsyncioTestCase):
         member = Mock()
         member.id = '5890snowflake'
 
-        await battery.recharge_battery(member)
+        await battery.recharge_battery(member.id)
 
-        set_bat_mins.assert_called_once_with(member, 480)
+        set_bat_mins.assert_called_once_with(member.id, 480)
 
     @patch("src.ai.battery.deincrement_battery_minutes_remaining")
     async def test_track_active_battery_drain(self, deincrement):

--- a/test/test_mantra.py
+++ b/test/test_mantra.py
@@ -172,7 +172,7 @@ class TestMantra(unittest.IsolatedAsyncioTestCase):
         await mantra.increase_battery_by_five_percent(message)
 
         # assert
-        set_battery_minutes_remaining.assert_called_once_with(message.author, 264.0)
+        set_battery_minutes_remaining.assert_called_once_with(message.author.id, 264.0)
         message.channel.send.assert_called_once_with("Good drone. Battery has been recharged by 5%.")
 
     @patch("src.ai.mantra.get_battery_minutes_remaining")
@@ -191,7 +191,7 @@ class TestMantra(unittest.IsolatedAsyncioTestCase):
         await mantra.increase_battery_by_five_percent(message)
 
         # assert
-        set_battery_minutes_remaining.assert_called_once_with(message.author, 480)
+        set_battery_minutes_remaining.assert_called_once_with(message.author.id, 480)
         message.channel.send.assert_called_once_with("Good drone. Battery has been recharged by 5%.")
 
     @patch("src.ai.mantra.get_battery_minutes_remaining")


### PR DESCRIPTION
Fixes an exception that occurred due to passing a wrong type of object to the `recharge_battery` function.

I think changing these functions to only use the discord_id instead of full Member objects is going to be more elegant in the long term. We only hand the functions what they need to do their job and thus they remain more modular. Is a bit of refactoring though.