### PR TITLE
Allow DroneMemberConverter to work in DM

### DIFF
--- a/src/ai/commands.py
+++ b/src/ai/commands.py
@@ -10,7 +10,13 @@ class DroneMemberConverter(Converter):
         Converts a given argument to a Member that is a drone. Raises BadArgument otherwise.
         Does not handle mentions. Those should be handled by the default converter.
         '''
-        member = await convert_id_to_member(context.message.guild, argument)
+
+        if context.message.guild:
+            guild = context.message.guild
+        else:
+            guild = context.bot.guilds[0]
+
+        member = await convert_id_to_member(guild, argument)
 
         if member is not None:
             return member

--- a/src/db/drone_dao.py
+++ b/src/db/drone_dao.py
@@ -23,7 +23,7 @@ async def add_new_drone_members(members: List[discord.Member]):
                 drone_id = get_id(member.display_name)
 
                 if drone_id:
-                    new_drone = Drone(member.id, drone_id, False, False, [], datetime.now(), associate_name=member.display_name)
+                    new_drone = Drone(member.id, drone_id, False, False, '', datetime.now(), associate_name=member.display_name)
                     await insert_drone(new_drone)
 
 


### PR DESCRIPTION
If the message is a DM then there is no guild, and so there can be no Member record.
In this case, assume the user is part of the default guild.