### PR TITLE
Emoji IDs may be more than 18 digits

### DIFF
--- a/src/ai/glitch_message.py
+++ b/src/ai/glitch_message.py
@@ -20,7 +20,7 @@ MAX_DIACRITICS_PER_MESSAGE = 60
 MAX_DIACRITICS_PER_CHAR = 1
 glitcher = glitch_this.ImageGlitcher()
 
-protected_text_regex = re.compile(r'(<:(.*?):\d{18}>)|(\|\|.*\|\|)|(https?://\S+)')
+protected_text_regex = re.compile(r'(<:(.*?):\d{18,20}>)|(\|\|.*\|\|)|(https?://\S+)')
 
 
 def escape_characters(message: str, characters_regex):

--- a/test/test_glitch_message.py
+++ b/test/test_glitch_message.py
@@ -46,7 +46,7 @@ class GlitchMessageTest(unittest.TestCase):
 
     def test_escape_all(self):
         # init
-        message = "beep <:custom_emoji:123456789012345678> boop https://www.hexcorp.net beep ||this should not be glitched|| boop"
+        message = "beep <:custom_emoji:1234567890123456789> boop https://www.hexcorp.net beep ||this should not be glitched|| boop"
 
         # run
         _, modified_message = escape_characters(message, protected_text_regex)


### PR DESCRIPTION
Emojis have grown beyond 18 digits.  Make sure they don't get glitched.