### PR TITLE
Fix toggle_free_storage and associated tests

### DIFF
--- a/src/ai/drone_configuration.py
+++ b/src/ai/drone_configuration.py
@@ -56,7 +56,10 @@ class DroneConfigurationCog(Cog):
         '''
         Allows a drone to choose whether to be stored by anyone, or just its trusted users and the Hive Mxtress. Defaults to trusted users only.
         '''
-        await toggle_free_storage(context.bot.guilds[0].get_member(context.author.id))
+
+        member = context.bot.guilds[0].get_member(context.author.id)
+        drone_member = await DroneMember.create(member=member)
+        await toggle_free_storage(drone_member)
 
     @channels_only(OFFICE)
     @hive_mxtress_only()

--- a/test/test_drone_configuration.py
+++ b/test/test_drone_configuration.py
@@ -82,36 +82,44 @@ class DroneManagementTest(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(target.drone.is_battery_powered)
         self.assertTrue(target.drone.can_self_configure)
 
+    @patch('src.ai.drone_configuration.DroneMember')
     @cog(DroneConfigurationCog)
-    async def test_toggle_free_storage_enable(self, mocks: Mocks) -> None:
+    async def test_toggle_free_storage_enable(self, DroneMember: MagicMock, mocks: Mocks) -> None:
         # setup
-        author = mocks.drone_member('1234')
+        drone_member = mocks.drone_member('1234')
+        DroneMember.create = AsyncMock(return_value=drone_member)
+        author = mocks.member('1234')
         message = mocks.direct_command(author, 'toggle_free_storage')
 
         # run
         await self.assert_command_successful(message)
 
         # assert
-        self.assertTrue(author.drone.free_storage)
-        author.drone.save.assert_called_once()
+        self.assertTrue(drone_member.drone.free_storage)
+        drone_member.drone.save.assert_called_once()
 
+    @patch('src.ai.drone_configuration.DroneMember')
     @cog(DroneConfigurationCog)
-    async def test_toggle_free_storage_disable(self, mocks: Mocks) -> None:
+    async def test_toggle_free_storage_disable(self, DroneMember: MagicMock, mocks: Mocks) -> None:
         # setup
-        author = mocks.drone_member('1234', drone_free_storage=True)
+        drone_member = mocks.drone_member('1234', drone_free_storage=True)
+        DroneMember.create = AsyncMock(return_value=drone_member)
+        author = mocks.member('1234')
         message = mocks.direct_command(author, 'toggle_free_storage')
 
         # run
         await self.assert_command_successful(message)
 
         # assert
-        self.assertFalse(author.drone.free_storage)
-        author.drone.save.assert_called_once()
+        self.assertFalse(drone_member.drone.free_storage)
+        drone_member.drone.save.assert_called_once()
 
+    @patch('src.ai.drone_configuration.DroneMember')
     @cog(DroneConfigurationCog)
-    async def test_toggle_free_storage_not_drone(self, mocks: Mocks) -> None:
+    async def test_toggle_free_storage_not_drone(self, DroneMember: MagicMock, mocks: Mocks) -> None:
         # setup
-        author = mocks.drone_member('1234', drone=None)
+        DroneMember.create = AsyncMock(return_value=mocks.drone_member('1234', drone=None))
+        author = mocks.member('1234')
         message = mocks.direct_command(author, 'toggle_free_storage')
 
         # run


### PR DESCRIPTION
`toggle_free_storage()` now takes a `DroneMember` not a `Member`.  Ensure that `message.author` in tests is mocked as a `Member` not a `DroneMember`.

Closes #472