### PR TITLE
Fix drone release

### DIFF
--- a/src/ai/temporary_dronification.py
+++ b/src/ai/temporary_dronification.py
@@ -43,10 +43,19 @@ class TemporaryDronificationCog(Cog):
     @tasks.loop(minutes=1)
     @connect()
     async def release_temporary_drones(self):
-        log.info("Looking for temporary drones to release.")
+        '''
+        Release drones that have been dronified for a limited amount of time.
+        '''
+
         guild = self.bot.guilds[0]
+
         for drone in await fetch_all_elapsed_temporary_dronification():
-            await unassign_drone(guild.get_member(drone.discord_id))
+            member = guild.get_member(drone.discord_id)
+
+            if member is not None:
+                log.info(f"Releasing {drone.drone_id} from temporary dronification")
+                drone_member = await DroneMember.create(member)
+                await unassign_drone(drone_member)
 
     @guild_only()
     @command(usage=f'{COMMAND_PREFIX}temporarily_dronify @AssociateName 6')

--- a/test/cog.py
+++ b/test/cog.py
@@ -1,6 +1,5 @@
 from discord import Message
 from discord.ext.commands import Bot, Cog, CommandError, Context, Converter, Greedy, MemberNotFound
-from discord.utils import find
 from functools import wraps
 from inspect import iscoroutinefunction
 from re import match, sub

--- a/test/cog.py
+++ b/test/cog.py
@@ -15,46 +15,38 @@ class MockDroneMemberConverter(Converter):
     A parameter converter to automatically create DroneMember objects from command parameters.
     '''
 
-    async def convert(self, context: Context, argument: str):
+    async def convert(self, context: Context, argument: str) -> DroneMember:
         '''
         Try to find a DroneMember that matches the "argument" string.
         '''
-
-        member = None
 
         if context.guild:
             guild = context.guild
         else:
             guild = context.bot.guilds[0]
 
-        members = guild._members.values()
-
-        # Match by Discord ID.
-        # An ID is an int with 15 to 20 digits.
+        # See if argument is a mention.
+        # A Discord ID is an int with 15 to 20 digits.
         # Matches <@ID>, <#ID>.
         discord_id = match(r"<(?:@[!&]?|#)([0-9]{15,20})>$", argument)
 
         if discord_id is not None:
             discord_id = int(sub('[^0-9]', '', discord_id.group(1)))
-            member = guild._members.get(discord_id)
 
-        # Match by member name or nickname.
-        if member is None:
-            member = find(lambda m: m.name == argument or m.nick == argument, members)
+        for id, drone_member in guild._drone_members.items():
+            # Match by Discord ID.
+            if id == discord_id:
+                return drone_member
 
-        # Match by drone ID.
-        if member is None:
-            for m in members:
-                drone = getattr(m, 'drone', None)
+            # Match by name or nickname.
+            if drone_member.name == argument or drone_member.nick == argument:
+                return drone_member
 
-                if drone is not None and str(drone.drone_id) == argument:
-                    member = m
-                    break
+            # Match by drone ID.
+            if drone_member.drone and drone_member.drone.drone_id == argument:
+                return drone_member
 
-        if member is None:
-            raise MemberNotFound(argument)
-
-        return member
+        raise MemberNotFound(argument)
 
 
 def cog(CogType: Type[Cog]) -> Callable[[Any, Any], Any]:

--- a/test/mocks.py
+++ b/test/mocks.py
@@ -168,6 +168,10 @@ class Mocks():
 
         guild.get_member = lambda discord_id: self.find(guild._members, id=discord_id)
 
+        # Keep a dict of discord ID DroneMember so that MockDroneMemberConverter can return existing records
+        # rather than creating a new one.
+        guild._drone_members = {}
+
         return guild
 
     def record(self, spec=Record, **kwargs) -> Any:
@@ -318,6 +322,7 @@ class Mocks():
         member.edit = AsyncMock()
         member.mention = '<@' + str(member.id) + '>'
         member.joined_at = datetime.now(timezone.utc) - timedelta(weeks=3)
+        member.guild = self._guild
 
         self.set_props(member, kwargs)
 
@@ -434,40 +439,29 @@ class Mocks():
         '''
 
         drone_id = str(drone_id)
-        discord_id = int('111111111111111' + str(drone_id))
         nick = 'Drone-' + drone_id
 
         drone_member = create_autospec(DroneMember)
 
         if kwargs.get('member', None) is not None:
             member = kwargs.get('member')
-
-            drone_member.id = member.id
-            drone_member.bot = member.bot
-            drone_member._avatar = member._avatar
-            drone_member.nick = member.nick
-            drone_member.display_name = member.display_name
-            drone_member.edit = member.edit
-            drone_member.guild = member.guild
-            drone_member.mention = member.mention
-            drone_member._roles = member._roles
-            drone_member.roles = member.roles
-            drone_member.joined_at = member.joined_at
         else:
-            drone_member.id = discord_id
-            drone_member.bot = False
-            drone_member._avatar = 'Pretty avatar'
-            drone_member.nick = nick
-            drone_member.display_name = nick
-            drone_member.edit = AsyncMock()
-            drone_member.guild = self._guild
-            drone_member.mention = f'<@{discord_id}>'
-            drone_member._roles = []
-            drone_member.roles = []
-            drone_member.joined_at = datetime.now(timezone.utc) - timedelta(weeks=3)
+            member = self.member(nick, id=int('111111111111111' + str(drone_id)))
+
+        drone_member.id = member.id
+        drone_member.bot = member.bot
+        drone_member._avatar = member._avatar
+        drone_member.nick = member.nick
+        drone_member.display_name = member.display_name
+        drone_member.edit = member.edit
+        drone_member.guild = member.guild
+        drone_member.mention = member.mention
+        drone_member._roles = member._roles
+        drone_member.roles = member.roles
+        drone_member.joined_at = member.joined_at
 
         if 'drone' not in kwargs:
-            drone_member.drone = self.drone(drone_id)
+            drone_member.drone = self.drone(drone_id, discord_id=member.id)
 
         drone_member.avatar_url.return_value = drone_member._avatar
 
@@ -509,8 +503,7 @@ class Mocks():
         if drone_member.drone is not None:
             drone_member.drone.discord_id = drone_member.id
 
-        # Add the DroneMember to the guild.  This should really be just a Member, not a DroneMember.
-        self._guild._members[drone_member.id] = drone_member
+        self._guild._drone_members[drone_member.id] = drone_member
 
         return drone_member
 

--- a/test/test_battery.py
+++ b/test/test_battery.py
@@ -128,13 +128,14 @@ class TestBattery(unittest.IsolatedAsyncioTestCase):
         by DMing them.
         '''
 
-        drone_member = mocks.drone_member('1234', drone_is_battery_powered=True)
+        member = mocks.member('Drone-1234')
+        drone_member = mocks.drone_member('1234', member=member, drone_is_battery_powered=True)
         drone_member.drone.get_battery_percent_remaining = Mock(return_value=25)
         Drone.all.return_value = [drone_member.drone]
 
         await test_utils.start_and_await_loop(mocks.get_cog().warn_low_battery_drones)
 
-        drone_member.send.assert_called_once_with("Attention. Your battery is low (30%). Please connect to main power grid in the Storage Facility immediately.")
+        member.send.assert_called_once_with("Attention. Your battery is low (30%). Please connect to main power grid in the Storage Facility immediately.")
         self.assertTrue('1234' in mocks.get_cog().low_battery_drones)
 
     @patch('src.ai.battery.Drone', new_callable=AsyncMock)

--- a/test/test_temporary_dronification.py
+++ b/test/test_temporary_dronification.py
@@ -95,10 +95,13 @@ class TestTemporaryDronification(unittest.IsolatedAsyncioTestCase):
         create_drone.assert_not_called()
 
     @patch('src.ai.temporary_dronification.fetch_all_elapsed_temporary_dronification')
-    async def test_release_temporary_drones(self, fetch_all_elapsed_temporary_dronification) -> None:
-        member = self.mocks.drone_member('5555')
-        fetch_all_elapsed_temporary_dronification.return_value = [member.drone]
+    @patch('src.ai.temporary_dronification.DroneMember')
+    async def test_release_temporary_drones(self, DroneMember: MagicMock, fetch_all_elapsed_temporary_dronification) -> None:
+        member = self.mocks.member('Drone 5555')
+        drone_member = self.mocks.drone_member('5555', member=member)
+        fetch_all_elapsed_temporary_dronification.return_value = [drone_member.drone]
+        DroneMember.create = AsyncMock(return_value=drone_member)
 
         await test_utils.start_and_await_loop(self.mocks.get_cog().release_temporary_drones)
 
-        member.drone.delete.assert_called_once()
+        drone_member.drone.delete.assert_called_once()

--- a/test/test_trusted_user.py
+++ b/test/test_trusted_user.py
@@ -13,8 +13,8 @@ class TrustedUserTest(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self, mocks: Mocks):
         self.mocks = mocks
         self.mocks.get_cog().trusted_user_requests = []
-        self.issuer = mocks.drone_member(1234)
-        self.target = mocks.drone_member(9999)
+        self.issuer = mocks.drone_member('1234')
+        self.target = mocks.drone_member('9999')
 
     @patch('src.ai.trusted_user.DroneMember', new_callable=AsyncMock)
     async def test_successful_request(self, DroneMember: AsyncMock):


### PR DESCRIPTION
Fix an error in `release_temporary_drones()`

Rework `DroneMember` mocks so they don't get written to `guild.members`. Only `Member`s should be there.